### PR TITLE
Minor fixes

### DIFF
--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -25,6 +25,7 @@
   </developers>
 
   <properties>
+    <version.poi>3.2-FINAL</version.poi>
     <version.dbunit>2.4.8</version.dbunit>
     <version.cdi>1.0-SP1</version.cdi>
     <version.fest.assert>1.4</version.fest.assert>
@@ -69,7 +70,7 @@
     <dependency>
       <groupId>org.apache.poi</groupId>
       <artifactId>poi</artifactId>
-      <version>3.2-FINAL</version>
+      <version>${version.poi}</version>
     </dependency>
 
     <dependency>
@@ -123,19 +124,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.jboss.arquillian.core</groupId>
-      <artifactId>arquillian-core-impl-base</artifactId>
-      <scope>provided</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.jboss.shrinkwrap</groupId>
       <artifactId>shrinkwrap-impl-base</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.jboss.shrinkwrap.resolver</groupId>
-      <artifactId>shrinkwrap-resolver-impl-maven</artifactId>
     </dependency>
 
     <!-- Test dependencies -->

--- a/impl/src/main/java/org/jboss/arquillian/persistence/PersistenceTestHandler.java
+++ b/impl/src/main/java/org/jboss/arquillian/persistence/PersistenceTestHandler.java
@@ -17,7 +17,7 @@
  */
 package org.jboss.arquillian.persistence;
 
-import javax.naming.InitialContext;
+import javax.naming.Context;
 import javax.naming.NamingException;
 import javax.sql.DataSource;
 
@@ -45,7 +45,7 @@ import org.jboss.arquillian.test.spi.event.suite.BeforeClass;
 public class PersistenceTestHandler
 {
 
-   @Inject @ClassScoped
+   @Inject
    private Instance<PersistenceConfiguration> configuration;
    
    @Inject @ClassScoped
@@ -54,21 +54,24 @@ public class PersistenceTestHandler
    @Inject @TestScoped
    private InstanceProducer<javax.sql.DataSource> dataSourceProducer;
    
-   @Inject @TestScoped
+   @Inject
    private Event<PrepareData> prepareDataEvent;
    
-   @Inject @TestScoped
+   @Inject
    private Event<CompareData> compareDataEvent;
 
-   @Inject @TestScoped
+   @Inject
    private Event<CleanUpData> cleanUpDataEvent;
    
-   @Inject @TestScoped
+   @Inject
    private Event<TransactionStarted> transactionStartedEvent;
 
-   @Inject @TestScoped
+   @Inject
    private Event<TransactionFinished> transactionFinishedEvent;
    
+   @Inject
+   private Instance<Context> contextInst;
+
    public void beforeSuite(@Observes BeforeClass beforeClass)
    {
       metadataExtractor.set(new MetadataExtractor(beforeClass.getTestClass()));
@@ -122,7 +125,11 @@ public class PersistenceTestHandler
    {
       try
       {
-         final InitialContext context = new InitialContext();
+         final Context context = contextInst.get();
+         if(context == null)
+         {
+            throw new DataSourceNotFoundException("No Naming Context available");
+         }
          return (javax.sql.DataSource) context.lookup(dataSourceName);
       }
       catch (NamingException e)

--- a/impl/src/main/java/org/jboss/arquillian/persistence/data/dbunit/DBUnitDataStateLogger.java
+++ b/impl/src/main/java/org/jboss/arquillian/persistence/data/dbunit/DBUnitDataStateLogger.java
@@ -33,8 +33,6 @@ import org.jboss.arquillian.persistence.data.dbunit.exception.DBUnitDataSetHandl
 import org.jboss.arquillian.persistence.event.CleanUpData;
 import org.jboss.arquillian.persistence.event.PrepareData;
 import org.jboss.arquillian.test.spi.TestClass;
-import org.jboss.arquillian.test.spi.annotation.SuiteScoped;
-import org.jboss.arquillian.test.spi.annotation.TestScoped;
 import org.jboss.arquillian.test.spi.event.suite.TestEvent;
 
 /**
@@ -72,10 +70,10 @@ public class DBUnitDataStateLogger implements DataStateLogger
 
    private static final String FILENAME_PATTERN = "[%s]-%s#%s-%s.xml";
    
-   @Inject @TestScoped
+   @Inject
    private Instance<DatabaseConnection> databaseConnection;
    
-   @Inject @SuiteScoped
+   @Inject
    private Instance<PersistenceConfiguration> configuration;
    
    @Override

--- a/impl/src/main/java/org/jboss/arquillian/persistence/data/dbunit/DBUnitDatasetHandler.java
+++ b/impl/src/main/java/org/jboss/arquillian/persistence/data/dbunit/DBUnitDatasetHandler.java
@@ -36,19 +36,17 @@ import org.jboss.arquillian.persistence.data.dbunit.exception.DBUnitDataSetHandl
 import org.jboss.arquillian.persistence.event.CleanUpData;
 import org.jboss.arquillian.persistence.event.CompareData;
 import org.jboss.arquillian.persistence.event.PrepareData;
-import org.jboss.arquillian.test.spi.annotation.SuiteScoped;
-import org.jboss.arquillian.test.spi.annotation.TestScoped;
 
 public class DBUnitDatasetHandler implements DataHandler
 {
 
-   @Inject @TestScoped
+   @Inject
    private Instance<DatabaseConnection> databaseConnection;
    
-   @Inject @TestScoped
+   @Inject
    private Instance<DataSetRegister> dataSetRegister;
    
-   @Inject @SuiteScoped
+   @Inject
    private Instance<PersistenceConfiguration> configuration;
    
    @Override

--- a/impl/src/main/java/org/jboss/arquillian/persistence/data/dbunit/DBUnitPersistenceTestLifecycleHandler.java
+++ b/impl/src/main/java/org/jboss/arquillian/persistence/data/dbunit/DBUnitPersistenceTestLifecycleHandler.java
@@ -49,7 +49,7 @@ import org.jboss.arquillian.test.spi.annotation.TestScoped;
 public class DBUnitPersistenceTestLifecycleHandler
 {
 
-   @Inject @TestScoped
+   @Inject
    private Instance<DataSource> databaseSourceInstance;
 
    @Inject @TestScoped

--- a/impl/src/main/java/org/jboss/arquillian/persistence/deployment/PersistenceExtensionArchiveAppender.java
+++ b/impl/src/main/java/org/jboss/arquillian/persistence/deployment/PersistenceExtensionArchiveAppender.java
@@ -19,13 +19,9 @@ package org.jboss.arquillian.persistence.deployment;
 
 import org.jboss.arquillian.container.test.spi.RemoteLoadableExtension;
 import org.jboss.arquillian.container.test.spi.client.deployment.AuxiliaryArchiveAppender;
-import org.jboss.arquillian.core.api.Instance;
-import org.jboss.arquillian.core.api.annotation.Inject;
 import org.jboss.arquillian.persistence.PersistenceTestHandler;
 import org.jboss.arquillian.persistence.client.PersistenceExtension;
-import org.jboss.arquillian.persistence.configuration.PersistenceConfiguration;
 import org.jboss.arquillian.persistence.container.RemotePersistenceExtension;
-import org.jboss.arquillian.test.spi.TestClass;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.Filters;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -42,13 +38,6 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
  */
 public class PersistenceExtensionArchiveAppender implements AuxiliaryArchiveAppender
 {
-
-   @Inject
-   Instance<TestClass> testClass;
-   
-   @Inject
-   Instance<PersistenceConfiguration> configuration;
-   
    @Override
    public Archive<?> createAuxiliaryArchive()
    {

--- a/impl/src/main/java/org/jboss/arquillian/persistence/transaction/TransactionalWrapper.java
+++ b/impl/src/main/java/org/jboss/arquillian/persistence/transaction/TransactionalWrapper.java
@@ -17,7 +17,7 @@
  */
 package org.jboss.arquillian.persistence.transaction;
 
-import javax.naming.InitialContext;
+import javax.naming.Context;
 import javax.naming.NamingException;
 import javax.transaction.UserTransaction;
 
@@ -28,24 +28,31 @@ import org.jboss.arquillian.persistence.TransactionMode;
 import org.jboss.arquillian.persistence.configuration.PersistenceConfiguration;
 import org.jboss.arquillian.persistence.event.TransactionFinished;
 import org.jboss.arquillian.persistence.event.TransactionStarted;
+import org.jboss.arquillian.persistence.exception.DataSourceNotFoundException;
 import org.jboss.arquillian.persistence.metadata.MetadataExtractor;
 import org.jboss.arquillian.persistence.metadata.MetadataProvider;
-import org.jboss.arquillian.test.spi.annotation.SuiteScoped;
 
 public class TransactionalWrapper
 {
 
-   @Inject @SuiteScoped
+   @Inject
    private Instance<PersistenceConfiguration> configuration;
    
-   @Inject @SuiteScoped
+   @Inject
    private Instance<MetadataExtractor> metadataExtractor;
+
+   @Inject
+   private Instance<Context> contextInst;
 
    private UserTransaction obtainTransaction()
    {
       try
       {
-         final InitialContext context = new InitialContext();
+         final Context context = contextInst.get();
+         if(context == null)
+         {
+            throw new DataSourceNotFoundException("No Naming Context available");
+         }
          return (UserTransaction) context.lookup(configuration.get().getUserTransactionJndi());
       }
       catch (NamingException e)

--- a/int-tests/pom.xml
+++ b/int-tests/pom.xml
@@ -26,7 +26,9 @@
   </developers>
 
   <properties>
-    <version.arq.container.glassfish>1.0.0.Final-SNAPSHOT</version.arq.container.glassfish>
+    <version.arq.container.glassfish>1.0.0.CR2</version.arq.container.glassfish>
+    <version.jbossas_7>7.0.2.Final</version.jbossas_7>
+    <version.jbossas_spec>1.0.0.Final</version.jbossas_spec>
     <version.cdi>1.0-SP1</version.cdi>
     <version.hsqldb>1.8.0.10</version.hsqldb>
     <version.fest.assert>1.4</version.fest.assert>
@@ -99,9 +101,6 @@
   <profiles>
     <profile>
       <id>glassfish-3.1-embedded</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
       <dependencies>
           <dependency>
             <groupId>org.jboss.arquillian.container</groupId>
@@ -129,21 +128,57 @@
     </profile>
     <profile>
       <id>jbossas-7-managed</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
       <dependencies>
+        <dependency>
+          <groupId>org.jboss.arquillian.protocol</groupId>
+          <artifactId>arquillian-protocol-servlet</artifactId>
+          <scope>test</scope>
+        </dependency>
         <dependency>
           <groupId>org.jboss.spec</groupId>
           <artifactId>jboss-javaee-6.0</artifactId>
-          <version>1.0.0.Final</version>
+          <version>${version.jbossas_spec}</version>
           <type>pom</type>
           <scope>provided</scope>
         </dependency>
         <dependency>
           <groupId>org.jboss.as</groupId>
           <artifactId>jboss-as-arquillian-container-managed</artifactId>
-          <version>7.0.2.Final</version>
+          <version>${version.jbossas_7}</version>
         </dependency>
       </dependencies>
       <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <version>2.1</version>
+            <executions>
+              <execution>
+                <id>unpack</id>
+                <phase>process-test-classes</phase>
+                <goals>
+                  <goal>unpack</goal>
+                </goals>
+                <configuration>
+                  <artifactItems>
+                    <artifactItem>
+                      <groupId>org.jboss.as</groupId>
+                      <artifactId>jboss-as-dist</artifactId>
+                      <version>${version.jbossas_7}</version>
+                      <type>zip</type>
+                      <overWrite>false</overWrite>
+                      <outputDirectory>${project.build.directory}</outputDirectory>
+                    </artifactItem>
+                  </artifactItems>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
         <testResources>
           <testResource>
             <directory>src/test/resources</directory>

--- a/int-tests/src/test/java/org/jboss/arquillian/example/UserPersistenceTest.java
+++ b/int-tests/src/test/java/org/jboss/arquillian/example/UserPersistenceTest.java
@@ -23,8 +23,6 @@ import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.example.Address;
-import org.jboss.arquillian.example.UserAccount;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.persistence.Data;
 import org.jboss.arquillian.persistence.Expected;

--- a/int-tests/src/test/resources-jboss-7.0.2/arquillian.xml
+++ b/int-tests/src/test/resources-jboss-7.0.2/arquillian.xml
@@ -4,10 +4,13 @@
   xsi:schemaLocation="http://jboss.org/schema/arquillian
     http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
 
+<!-- 
+  <defaultProtocol type="Servlet 3.0" />
+-->
   <container qualifier="jboss7" default="true">
-    <protocol type="jmx-as7">
-      <property name="executionType">REMOTE</property>
-    </protocol>
+    <configuration>
+      <property name="jbossHome">target/jboss-as-7.0.2.Final</property>
+    </configuration>
   </container>
 
   <extension qualifier="persistence">

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
   <properties>
 
     <!-- Versioning -->
-    <version.arquillian_core>1.0.0.Final-SNAPSHOT</version.arquillian_core>
+    <version.arquillian_core>1.0.0.CR5</version.arquillian_core>
 
     <!-- override from parent -->
     <version.release.plugin>2.1</version.release.plugin>


### PR DESCRIPTION
- Move versioned artifacts to properties/version.xxx
- Remove some unused dependencies
- Downgrade to stable Arquillian Core and GlassFish Container versions
- Remove unused @ClassScope @TestScope scope annotations from Instance and Event injection points (only required by InstanceProducer)
- Change to get the InitialContext via the Arquillian Contexts instead of creating it
- Remove unused variables
- Add download and extraction of JBoss AS 7 in the AS7 Managed profile
- Change default Profile to be AS7 Managed (this adds the 'remoteness' aspects to the default tests)
