### PR TITLE
[ARQ-653] Reworked configuration sharing between client and container side.

### DIFF
--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
   <!-- Parent -->
   <parent>
@@ -39,6 +40,12 @@
       <groupId>org.jboss.arquillian.extension</groupId>
       <artifactId>arquillian-persistence-api</artifactId>
       <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>10.0.1</version>
     </dependency>
 
     <dependency>

--- a/impl/src/main/java/org/jboss/arquillian/persistence/client/PersistenceConfigurationProducer.java
+++ b/impl/src/main/java/org/jboss/arquillian/persistence/client/PersistenceConfigurationProducer.java
@@ -10,7 +10,7 @@
  * You may obtain a copy of the License at
  * http://www.apache.org/licenses/LICENSE-2.0
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,  
+ * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
@@ -18,42 +18,35 @@
 package org.jboss.arquillian.persistence.client;
 
 import org.jboss.arquillian.config.descriptor.api.ArquillianDescriptor;
-import org.jboss.arquillian.container.test.spi.command.Command;
 import org.jboss.arquillian.core.api.Instance;
 import org.jboss.arquillian.core.api.InstanceProducer;
+import org.jboss.arquillian.core.api.annotation.ApplicationScoped;
 import org.jboss.arquillian.core.api.annotation.Inject;
 import org.jboss.arquillian.core.api.annotation.Observes;
-import org.jboss.arquillian.persistence.command.ConfigurationCommand;
+import org.jboss.arquillian.persistence.configuration.ConfigurationExtractor;
 import org.jboss.arquillian.persistence.configuration.PersistenceConfiguration;
-import org.jboss.arquillian.test.spi.annotation.ClassScoped;
-import org.jboss.arquillian.test.spi.event.suite.BeforeClass;
+import org.jboss.arquillian.test.spi.event.suite.BeforeSuite;
 
 /**
- * 
- * Triggers configuration creation before executing tests and expose
- * it to the remote containers through {@link Command} mechanism.
- * 
+ *
+ * Triggers configuration creation on the client side.
+ *
  * @author <a href="mailto:bartosz.majsak@gmail.com">Bartosz Majsak</a>
  *
  */
 public class PersistenceConfigurationProducer
 {
-   @Inject
-   private Instance<ArquillianDescriptor> descriptor;
-   
-   @Inject @ClassScoped
+   @Inject @ApplicationScoped
+   Instance<ArquillianDescriptor> descriptor;
+
+   @Inject @ApplicationScoped
    InstanceProducer<PersistenceConfiguration> configurationProducer;
-   
-   public void configure(@Observes BeforeClass beforeClassEvent)
+
+   public void configure(@Observes BeforeSuite beforeSuiteEvent)
    {
       ConfigurationExtractor extractor = new ConfigurationExtractor(descriptor.get());
       PersistenceConfiguration configuration = extractor.extract();
       configurationProducer.set(configuration);
-   }
-   
-   public void listen(@Observes ConfigurationCommand configurationCommand)
-   {
-      configurationCommand.setResult(configurationProducer.get());
    }
 
 }

--- a/impl/src/main/java/org/jboss/arquillian/persistence/configuration/ConfigurationExtractor.java
+++ b/impl/src/main/java/org/jboss/arquillian/persistence/configuration/ConfigurationExtractor.java
@@ -10,12 +10,12 @@
  * You may obtain a copy of the License at
  * http://www.apache.org/licenses/LICENSE-2.0
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,  
+ * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.arquillian.persistence.client;
+package org.jboss.arquillian.persistence.configuration;
 
 import java.util.Collections;
 import java.util.Map;
@@ -23,34 +23,33 @@ import java.util.Map;
 import org.jboss.arquillian.config.descriptor.api.ArquillianDescriptor;
 import org.jboss.arquillian.config.descriptor.api.ExtensionDef;
 import org.jboss.arquillian.persistence.TransactionMode;
-import org.jboss.arquillian.persistence.configuration.PersistenceConfiguration;
 import org.jboss.arquillian.persistence.data.Format;
 
 /**
- * 
+ *
  * Fetches persistence-related configuration from <code>arquillian.xml</code>
  * and creates {@see PersistenceConfiguration} instance used during tests
  * execution.
- * 
+ *
  * @author <a href="mailto:bartosz.majsak@gmail.com">Bartosz Majsak</a>
  *
  */
-class ConfigurationExtractor
+public class ConfigurationExtractor
 {
 
    private static final String PERSISTENCE_EXTENSION_QUALIFIER = "persistence";
-   
+
    private final ArquillianDescriptor descriptor;
-   
-   ConfigurationExtractor(ArquillianDescriptor descriptor)
+
+   public ConfigurationExtractor(ArquillianDescriptor descriptor)
    {
       this.descriptor = descriptor;
    }
 
-   PersistenceConfiguration extract()
+   public PersistenceConfiguration extract()
    {
       final Map<String, String> extensionProperties = extractProperties(PERSISTENCE_EXTENSION_QUALIFIER);
-      
+
       final PersistenceConfiguration configuration = new PersistenceConfiguration();
       configuration.setDefaultDataSource(extensionProperties.get("defaultDataSource"));
       configuration.setInitStatement(extensionProperties.get("initStatement"));
@@ -60,13 +59,13 @@ class ConfigurationExtractor
       {
          configuration.setDefaultDataSetFormat(Format.valueOf(defaultDataSetFormat.toUpperCase()));
       }
-      
+
       String defaultTransactionMode = extensionProperties.get("defaultTransactionMode");
       if (defaultTransactionMode != null)
       {
          configuration.setDefaultTransactionMode(TransactionMode.valueOf(defaultTransactionMode.toUpperCase()));
       }
-      
+
       configuration.setDumpData(Boolean.parseBoolean(extensionProperties.get("dumpData")));
       String dumpDirectory = extensionProperties.get("dumpDirectory");
       if (dumpDirectory != null)
@@ -79,7 +78,7 @@ class ConfigurationExtractor
       {
          configuration.setUserTransactionJndi(userTransactionJndi);
       }
-      
+
       return configuration;
    }
 

--- a/impl/src/main/java/org/jboss/arquillian/persistence/container/RemotePersistenceExtension.java
+++ b/impl/src/main/java/org/jboss/arquillian/persistence/container/RemotePersistenceExtension.java
@@ -19,6 +19,7 @@ package org.jboss.arquillian.persistence.container;
 
 import org.jboss.arquillian.container.test.spi.RemoteLoadableExtension;
 import org.jboss.arquillian.persistence.PersistenceTestHandler;
+import org.jboss.arquillian.persistence.configuration.RemotePersistenceConfigurationProducer;
 import org.jboss.arquillian.persistence.data.dbunit.DBUnitDataStateLogger;
 import org.jboss.arquillian.persistence.data.dbunit.DBUnitDatasetHandler;
 import org.jboss.arquillian.persistence.data.dbunit.DBUnitPersistenceTestLifecycleHandler;
@@ -37,7 +38,7 @@ public class RemotePersistenceExtension implements RemoteLoadableExtension
    @Override
    public void register(ExtensionBuilder builder)
    {
-      builder.observer(ConfigurationLoader.class)
+      builder.observer(RemotePersistenceConfigurationProducer.class)
              .observer(CommandServiceProducer.class)
              .observer(PersistenceTestHandler.class)
              .observer(TransactionalWrapper.class);
@@ -45,6 +46,7 @@ public class RemotePersistenceExtension implements RemoteLoadableExtension
       builder.observer(DBUnitDatasetHandler.class)
              .observer(DBUnitPersistenceTestLifecycleHandler.class)
              .observer(DBUnitDataStateLogger.class);
+
    }
 
 }

--- a/impl/src/main/java/org/jboss/arquillian/persistence/deployment/PersistenceExtensionArchiveAppender.java
+++ b/impl/src/main/java/org/jboss/arquillian/persistence/deployment/PersistenceExtensionArchiveAppender.java
@@ -17,15 +17,22 @@
  */
 package org.jboss.arquillian.persistence.deployment;
 
+import org.jboss.arquillian.config.descriptor.api.ArquillianDescriptor;
 import org.jboss.arquillian.container.test.spi.RemoteLoadableExtension;
 import org.jboss.arquillian.container.test.spi.client.deployment.AuxiliaryArchiveAppender;
+import org.jboss.arquillian.core.api.Instance;
+import org.jboss.arquillian.core.api.annotation.Inject;
 import org.jboss.arquillian.persistence.PersistenceTestHandler;
 import org.jboss.arquillian.persistence.client.PersistenceExtension;
+import org.jboss.arquillian.persistence.configuration.PersistenceConfiguration;
 import org.jboss.arquillian.persistence.container.RemotePersistenceExtension;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.Filters;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.Asset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.yaml.snakeyaml.Yaml;
 
 /**
  *
@@ -38,9 +45,13 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
  */
 public class PersistenceExtensionArchiveAppender implements AuxiliaryArchiveAppender
 {
+   @Inject
+   Instance<PersistenceConfiguration> configuration;
+
    @Override
    public Archive<?> createAuxiliaryArchive()
    {
+      final String persistenceConfigurationInYaml = new Yaml().dump(configuration.get());
       JavaArchive archive = ShrinkWrap.create(JavaArchive.class, "arquillian-persistence.jar")
                                       .addPackages(true,
                                             // exclude client package
@@ -53,9 +64,10 @@ public class PersistenceExtensionArchiveAppender implements AuxiliaryArchiveAppe
                                             "org.apache.log4j",
                                             "org.slf4j",
                                             "org.yaml")
+                                      .addAsResource(new StringAsset(persistenceConfigurationInYaml),
+                                            "persistence-config.yml")
                                       .addAsServiceProvider(RemoteLoadableExtension.class,
                                             RemotePersistenceExtension.class);
-
       return archive;
    }
 

--- a/impl/src/main/resources/META-INF/services/org.jboss.arquillian.config.descriptor.api.ArquillianDescriptor
+++ b/impl/src/main/resources/META-INF/services/org.jboss.arquillian.config.descriptor.api.ArquillianDescriptor
@@ -1,0 +1,3 @@
+implClass=org.jboss.arquillian.config.descriptor.impl.ArquillianDescriptorImpl
+importerClass=org.jboss.shrinkwrap.descriptor.spi.node.dom.XmlDomNodeDescriptorImporterImpl
+defaultName=arquillian.xml

--- a/impl/src/test/java/org/jboss/arquillian/persistence/configuration/ConfigurationExtractorTest.java
+++ b/impl/src/test/java/org/jboss/arquillian/persistence/configuration/ConfigurationExtractorTest.java
@@ -15,12 +15,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.arquillian.persistence.client;
+package org.jboss.arquillian.persistence.configuration;
 
 import static org.fest.assertions.Assertions.assertThat;
 
 import org.jboss.arquillian.persistence.TransactionMode;
-import org.jboss.arquillian.persistence.client.ConfigurationExtractor;
 import org.jboss.arquillian.persistence.configuration.PersistenceConfiguration;
 import org.jboss.arquillian.persistence.data.Format;
 import org.junit.Test;

--- a/impl/src/test/java/org/jboss/arquillian/persistence/configuration/ConfigurationInitializationTest.java
+++ b/impl/src/test/java/org/jboss/arquillian/persistence/configuration/ConfigurationInitializationTest.java
@@ -10,7 +10,7 @@
  * You may obtain a copy of the License at
  * http://www.apache.org/licenses/LICENSE-2.0
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,  
+ * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
@@ -23,9 +23,10 @@ import java.util.List;
 
 import org.jboss.arquillian.config.descriptor.api.ArquillianDescriptor;
 import org.jboss.arquillian.core.api.annotation.ApplicationScoped;
+import org.jboss.arquillian.core.spi.context.ApplicationContext;
 import org.jboss.arquillian.persistence.client.PersistenceConfigurationProducer;
-import org.jboss.arquillian.test.spi.context.ClassContext;
-import org.jboss.arquillian.test.spi.event.suite.BeforeClass;
+import org.jboss.arquillian.test.spi.context.SuiteContext;
+import org.jboss.arquillian.test.spi.event.suite.BeforeSuite;
 import org.jboss.arquillian.test.test.AbstractTestTestBase;
 import org.jboss.shrinkwrap.descriptor.api.Descriptors;
 import org.junit.Before;
@@ -33,30 +34,29 @@ import org.junit.Test;
 
 public class ConfigurationInitializationTest extends AbstractTestTestBase {
 
-	@Override
-	protected void addExtensions(List<Class<?>> extensions) {
-		extensions.add(PersistenceConfigurationProducer.class);
-	}
+    @Override
+    protected void addExtensions(List<Class<?>> extensions) {
+        extensions.add(PersistenceConfigurationProducer.class);
+    }
 
-	@Before
-	public void initializeArquillianDescriptor() {
-		bind(ApplicationScoped.class, ArquillianDescriptor.class, Descriptors.create(ArquillianDescriptor.class));
-	}
-	
-	@Test
-	public void shouldCreateConfigurationBeforeClassIsExecuted() throws Exception {
-		// given
-	    getManager().getContext(ClassContext.class).activate(getClass());
-		BeforeClass beforeClassEvent = new BeforeClass(getClass());
-		
-		// when
-		fire(beforeClassEvent);
-		PersistenceConfiguration persistenceConfiguration = getManager().getContext(ClassContext.class)
-		                                                                .getObjectStore()
-		                                                                .get(PersistenceConfiguration.class);
-		
-		// then
-		assertThat(persistenceConfiguration).isNotNull();
-	}
+    @Before
+    public void initializeArquillianDescriptor() {
+        bind(ApplicationScoped.class, ArquillianDescriptor.class, Descriptors.create(ArquillianDescriptor.class));
+    }
+
+    @Test
+    public void shouldCreateConfigurationBeforeClassIsExecuted() throws Exception {
+        // given
+        getManager().getContext(SuiteContext.class).activate();
+
+        // when
+        fire(new BeforeSuite());
+        PersistenceConfiguration persistenceConfiguration = getManager().getContext(ApplicationContext.class)
+                                                                        .getObjectStore()
+                                                                        .get(PersistenceConfiguration.class);
+
+        // then
+        assertThat(persistenceConfiguration).isNotNull();
+    }
 
 }

--- a/impl/src/test/java/org/jboss/arquillian/persistence/configuration/ConfigurationLoader.java
+++ b/impl/src/test/java/org/jboss/arquillian/persistence/configuration/ConfigurationLoader.java
@@ -15,12 +15,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.arquillian.persistence.client;
+package org.jboss.arquillian.persistence.configuration;
 
 import java.io.InputStream;
 
 import org.jboss.arquillian.config.descriptor.api.ArquillianDescriptor;
-import org.jboss.arquillian.persistence.client.ConfigurationExtractor;
 import org.jboss.arquillian.persistence.configuration.PersistenceConfiguration;
 import org.jboss.shrinkwrap.descriptor.api.Descriptors;
 

--- a/impl/src/test/java/org/jboss/arquillian/persistence/metadata/DataSetProviderDataTest.java
+++ b/impl/src/test/java/org/jboss/arquillian/persistence/metadata/DataSetProviderDataTest.java
@@ -23,7 +23,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.jboss.arquillian.persistence.Data;
-import org.jboss.arquillian.persistence.client.ConfigurationLoader;
+import org.jboss.arquillian.persistence.configuration.ConfigurationLoader;
 import org.jboss.arquillian.persistence.configuration.PersistenceConfiguration;
 import org.jboss.arquillian.persistence.data.DataSetDescriptor;
 import org.jboss.arquillian.persistence.data.Format;

--- a/impl/src/test/java/org/jboss/arquillian/persistence/metadata/DataSetProviderExpectedTest.java
+++ b/impl/src/test/java/org/jboss/arquillian/persistence/metadata/DataSetProviderExpectedTest.java
@@ -24,7 +24,7 @@ import java.util.Set;
 
 import org.jboss.arquillian.persistence.Data;
 import org.jboss.arquillian.persistence.Expected;
-import org.jboss.arquillian.persistence.client.ConfigurationLoader;
+import org.jboss.arquillian.persistence.configuration.ConfigurationLoader;
 import org.jboss.arquillian.persistence.configuration.PersistenceConfiguration;
 import org.jboss.arquillian.persistence.data.DataSetDescriptor;
 import org.jboss.arquillian.persistence.data.Format;

--- a/impl/src/test/java/org/jboss/arquillian/persistence/metadata/MetadataProviderDataSourceTest.java
+++ b/impl/src/test/java/org/jboss/arquillian/persistence/metadata/MetadataProviderDataSourceTest.java
@@ -21,7 +21,7 @@ import static org.fest.assertions.Assertions.assertThat;
 
 import org.jboss.arquillian.persistence.Data;
 import org.jboss.arquillian.persistence.DataSource;
-import org.jboss.arquillian.persistence.client.ConfigurationLoader;
+import org.jboss.arquillian.persistence.configuration.ConfigurationLoader;
 import org.jboss.arquillian.persistence.configuration.PersistenceConfiguration;
 import org.jboss.arquillian.persistence.exception.DataSourceNotDefinedException;
 import org.jboss.arquillian.test.spi.event.suite.TestEvent;

--- a/impl/src/test/java/org/jboss/arquillian/persistence/metadata/MetadataProviderPersistentFeatureTest.java
+++ b/impl/src/test/java/org/jboss/arquillian/persistence/metadata/MetadataProviderPersistentFeatureTest.java
@@ -22,7 +22,7 @@ import static org.fest.assertions.Assertions.assertThat;
 import org.jboss.arquillian.persistence.Data;
 import org.jboss.arquillian.persistence.Expected;
 import org.jboss.arquillian.persistence.PersistenceTest;
-import org.jboss.arquillian.persistence.client.ConfigurationLoader;
+import org.jboss.arquillian.persistence.configuration.ConfigurationLoader;
 import org.jboss.arquillian.test.spi.event.suite.TestEvent;
 import org.junit.Test;
 

--- a/impl/src/test/java/org/jboss/arquillian/persistence/metadata/MetadataProviderTransactionalTest.java
+++ b/impl/src/test/java/org/jboss/arquillian/persistence/metadata/MetadataProviderTransactionalTest.java
@@ -21,7 +21,7 @@ import static org.fest.assertions.Assertions.assertThat;
 
 import org.jboss.arquillian.persistence.TransactionMode;
 import org.jboss.arquillian.persistence.Transactional;
-import org.jboss.arquillian.persistence.client.ConfigurationLoader;
+import org.jboss.arquillian.persistence.configuration.ConfigurationLoader;
 import org.jboss.arquillian.persistence.configuration.PersistenceConfiguration;
 import org.jboss.arquillian.test.spi.event.suite.TestEvent;
 import org.junit.Test;


### PR DESCRIPTION
It's using yaml serialization/deserialization to pass only relevant bits of the persistence extension configuration.

I was having troubles trying to use the same approach on the container side as it's used in ConfigurationRegistrar (Shrinkwrap). Details here: https://gist.github.com/1396309

Pros: compact representation with only relevant stuff for persistence extension.
Cons: different approach, additional dependency for the extension (if you don't want to use YAML for datasets).
