### PR TITLE
ARQ-692 Update to jboss-parent-8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jboss</groupId>
     <artifactId>jboss-parent</artifactId>
-    <version>7</version>
+    <version>8</version>
     <relativePath />
   </parent>
 
@@ -28,9 +28,9 @@
     <version.arquillian_core>1.0.0.CR6</version.arquillian_core>
 
     <!-- override from parent -->
-    <version.release.plugin>2.1</version.release.plugin>
-    <maven.compiler.target>1.5</maven.compiler.target>
-    <maven.compiler.source>1.5</maven.compiler.source>
+    <maven.compiler.argument.target>1.5</maven.compiler.argument.target>
+    <maven.compiler.argument.source>1.5</maven.compiler.argument.source>
+
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
Update to jboss-parent:8 that contains workaround for M2Eclipse importing projects as 1.5 source level. There is now a difference between the source level m2eclipse sees (1.6) and what maven compile user (1.5)
