### PR TITLE
[ARQ-1352] ScriptExecutor: fix regex matching comments in /* */ format

### DIFF
--- a/impl/src/main/java/org/jboss/arquillian/persistence/script/ScriptExecutor.java
+++ b/impl/src/main/java/org/jboss/arquillian/persistence/script/ScriptExecutor.java
@@ -58,7 +58,7 @@ import org.jboss.arquillian.persistence.script.configuration.ScriptingConfigurat
 public class ScriptExecutor
 {
 
-   private static final String ANSI_SQL_COMMENTS_PATTERN = "--.*|//.*|(?s)/\\\\*.*?\\\\*/|(?s)\\{.*?\\}";
+   private static final String ANSI_SQL_COMMENTS_PATTERN = "--.*|//.*|(?s)/\\*.*?\\*/|(?s)\\{.*?\\}";
 
    private static final String LINE_SEPARATOR = System.getProperty("line.separator", "\n");
 

--- a/impl/src/test/java/org/jboss/arquillian/persistence/script/ScriptExecutorTest.java
+++ b/impl/src/test/java/org/jboss/arquillian/persistence/script/ScriptExecutorTest.java
@@ -216,5 +216,20 @@ public class ScriptExecutorTest
             "END");
    }
 
+	@Test
+	public void should_insert_slash_as_value() throws Exception
+	{
+      // given
+      ArgumentCaptor<String> statementsCaptor = ArgumentCaptor.forClass(String.class);
+      scriptExecutor.setStatementDelimiter(ScriptingConfiguration.NEW_LINE_SYMBOL);
 
+      // when
+      scriptExecutor.execute(FileLoader.loadAsString("scripts/insert-slash.sql"));
+
+      // then
+      verify(connection, times(1)).createStatement();
+      verify(connection.createStatement(), times(1)).execute(statementsCaptor.capture());
+      assertThat(statementsCaptor.getAllValues())
+      .containsSequence("insert into useraccount (id, firstname, lastname, username, password) values  (1, 'John', 'Smith', 'doovde', 'pa/ss/wo/rd')");
+	}
 }

--- a/impl/src/test/resources/scripts/insert-slash.sql
+++ b/impl/src/test/resources/scripts/insert-slash.sql
@@ -1,0 +1,1 @@
+insert into useraccount (id, firstname, lastname, username, password) values /* inseerting slashes should be ok */ (1, 'John', 'Smith', 'doovde', 'pa/ss/wo/rd')


### PR DESCRIPTION
Here is the fix for the inserting slash as value problem.
I hope i got the unit test right.
