### PR TITLE
made POI an optional dependency

### DIFF
--- a/dbunit/pom.xml
+++ b/dbunit/pom.xml
@@ -86,6 +86,7 @@
       <groupId>org.apache.poi</groupId>
       <artifactId>poi</artifactId>
       <version>${version.poi}</version>
+      <optional>true</optional>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
POI is optional because it's only used for MS Excel support.

It seems minor, but org.apache.poi:poi pulls in log4j and other not nice deps
