### PR TITLE
Avoid packaging org.slf4j.impl.StaticLoggerBinder in arquillian-persi…

### DIFF
--- a/dbunit/src/main/java/org/jboss/arquillian/persistence/dbunit/deployment/DBUnitArchiveAppender.java
+++ b/dbunit/src/main/java/org/jboss/arquillian/persistence/dbunit/deployment/DBUnitArchiveAppender.java
@@ -55,7 +55,10 @@ public class DBUnitArchiveAppender implements AuxiliaryArchiveAppender
                                                                  // exclude client package
                                                                  Filters.exclude(DBUnitExtension.class.getPackage()),
                                                                  "org.jboss.arquillian.persistence.dbunit")
-                                                           .addPackages(true, requiredLibraries())
+                                                           .addPackages(true,
+                                                                   // Avoid slf4j implementation in case different impl is chosen in @Deployment
+                                                                   Filters.exclude(".*/org/slf4j/impl/.*"),
+                                                                   requiredLibraries())
                                                            .addAsServiceProvider(RemoteLoadableExtension.class, RemoteDBUnitExtension.class);
 
       return dbUnitExtensionArchive;


### PR DESCRIPTION
…stence-dbunit.jar

DBUnitArchiveAppender packages required classes into arquillian-persistence-dbunit.jar which is added as an auxiliary archive to the deployment.
One of the packages added is `org.slf4j` which also adds the class `org.slf4j.impl.StaticLoggerBinder` available via the test dependencies.
As the `@Deployment` will usually also add an slf4j impl slf4j will recognize two different resources `org.slf4j.impl.StaticLoggerBinder` and throw a warning message:
```
SLF4J: Class path contains multiple SLF4J bindings.
SLF4J: Found binding in [jar:file:/Users/robertpanzer/dev/myproject/webapp/target/arquillian/testapp/WEB-INF/lib/arquillian-persistence-dbunit.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/Users/robertpanzer/dev/myproject/webapp/target/arquillian/testapp/WEB-INF/lib/log4j-slf4j-impl-2.4.1.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
SLF4J: Actual binding is of type [org.apache.logging.slf4j.Log4jLoggerFactory]
```

As long as the Deployment packages the same implementation as is available via the test dependencies, this is not an issue as both classes will provide the same implementation.
But if the Deployment decides to package a different implementation for whatever reason one of the two implementations will be chosen by accident.

Very much explanation for a simple PR:
It simply excludes the org.slf4j.impl package.
If the Deployment choses to not add an implementation slf4j will automatically use the `org.slf4j.helpers.NOPLogger` which does just nothing.