### PR TITLE
Added missing dbunit Configuration feature 'allowEmptyFields'.

### DIFF
--- a/dbunit/src/main/java/org/jboss/arquillian/persistence/dbunit/configuration/DBUnitConfiguration.java
+++ b/dbunit/src/main/java/org/jboss/arquillian/persistence/dbunit/configuration/DBUnitConfiguration.java
@@ -40,8 +40,8 @@ import org.jboss.arquillian.persistence.util.Arrays;
  * descriptor in the element with qualifier <code>persistence-dbunit</code>.
  * <br><br>
  * Covers all features and properties described in
- * <a href="http://www.dbunit.org/properties.html">DBUnit documentation</a> as of
- * version 2.4.8
+ * <a href="http://dbunit.sourceforge.net/properties.html">DBUnit documentation</a> as of
+ * version 2.5.1
  *
  * @author <a href="mailto:bartosz.majsak@gmail.com">Bartosz Majsak</a>
  *
@@ -65,7 +65,10 @@ public class DBUnitConfiguration extends Configuration
 
    @Feature
    private boolean skipOracleRecycleBinTables = false;
-
+   
+   @Feature
+   private boolean allowEmptyFields = false;
+   
    @Property
    private String escapePattern;
 
@@ -194,6 +197,20 @@ public class DBUnitConfiguration extends Configuration
    public void setSkipOracleRecycleBinTables(boolean skipOracleRecycleBinTables)
    {
       this.skipOracleRecycleBinTables = skipOracleRecycleBinTables;
+   }
+
+   public boolean isAllowEmptyFields()
+   {
+      return allowEmptyFields;
+   }
+
+   /**
+    * @param allowEmptyFields Allow to call INSERT/UPDATE with empty strings ('').
+    * Default value is <code>false</code>.
+    */
+   public void setAllowEmptyFields(boolean allowEmptyFields)
+   {
+      this.allowEmptyFields = allowEmptyFields;
    }
 
    public String getEscapePattern()

--- a/dbunit/src/test/java/org/jboss/arquillian/persistence/dbunit/configuration/DBUnitConfigurationImporterFromFileAbstractTestCase.java
+++ b/dbunit/src/test/java/org/jboss/arquillian/persistence/dbunit/configuration/DBUnitConfigurationImporterFromFileAbstractTestCase.java
@@ -76,6 +76,15 @@ public abstract class DBUnitConfigurationImporterFromFileAbstractTestCase
       // then
       assertThat(dbunitConfiguration.isSkipOracleRecycleBinTables()).isTrue();
    }
+   
+   @Test
+   public void should_extract_allow_empty_fields_flag_from_external_property_file() throws Exception
+   {
+      DBUnitConfiguration dbunitConfiguration = loadFromFile();
+
+      // then
+      assertThat(dbunitConfiguration.isAllowEmptyFields()).isTrue();
+   }
 
    @Test
    public void should_extract_escape_pattern_from_external_property_file() throws Exception

--- a/dbunit/src/test/java/org/jboss/arquillian/persistence/dbunit/configuration/DBUnitConfigurationPropertyMapperTest.java
+++ b/dbunit/src/test/java/org/jboss/arquillian/persistence/dbunit/configuration/DBUnitConfigurationPropertyMapperTest.java
@@ -92,6 +92,7 @@ public class DBUnitConfigurationPropertyMapperTest
             JUnitParamsRunner.$(DBUNIT_FEATURES + "qualifiedTableNames", true),
             JUnitParamsRunner.$(DBUNIT_FEATURES + "datatypeWarning", false),
             JUnitParamsRunner.$(DBUNIT_FEATURES + "skipOracleRecycleBinTables", true),
+            JUnitParamsRunner.$(DBUNIT_FEATURES + "allowEmptyFields", true),
             JUnitParamsRunner.$(DBUNIT_PROPERTIES + "escapePattern", "?"),
             JUnitParamsRunner.$(DBUNIT_PROPERTIES + "batchSize", 200),
             JUnitParamsRunner.$(DBUNIT_PROPERTIES + "fetchSize", 300)

--- a/dbunit/src/test/resources/arquillian-dbunit.xml
+++ b/dbunit/src/test/resources/arquillian-dbunit.xml
@@ -10,6 +10,7 @@
     <property name="qualifiedTableNames">true</property>
     <property name="datatypeWarning">false</property>
     <property name="skipOracleRecycleBinTables">true</property>
+    <property name="allowEmptyFields">true</property>
     <property name="escapePattern">?</property>
     <property name="tableType">TABLE, VIEW</property>
     <property name="datatypeFactory">org.dbunit.ext.hsqldb.HsqldbDataTypeFactory</property>

--- a/dbunit/src/test/resources/properties/dbunit.custom.arquillian.persistence.properties
+++ b/dbunit/src/test/resources/properties/dbunit.custom.arquillian.persistence.properties
@@ -3,6 +3,7 @@ arquillian.extension.persistence.dbunit.caseSensitiveTableNames=true
 arquillian.extension.persistence.dbunit.qualifiedTableNames=true
 arquillian.extension.persistence.dbunit.datatypeWarning=false
 arquillian.extension.persistence.dbunit.skipOracleRecycleBinTables=true
+arquillian.extension.persistence.dbunit.allowEmptyFields=true
 arquillian.extension.persistence.dbunit.escapePattern=?
 arquillian.extension.persistence.dbunit.tableType=TABLE, VIEW
 arquillian.extension.persistence.dbunit.datatypeFactory=org.dbunit.ext.hsqldb.HsqldbDataTypeFactory


### PR DESCRIPTION
We found that we needed to set the feature allowEmptyFields in the dbunit configuration.

This commit adds the new feature and test for it.
I also changed the dbunit properties link in the documentation to the sourceforge link as dbunit.org currently no longer exists.

I am sure that having this feature in the final release of this project will help others who also need this feature.