### PR TITLE
[ARQ-2070] Adds possibility to strip statement delimiter from parsed statements

### DIFF
--- a/core/src/main/java/org/jboss/arquillian/persistence/script/configuration/ScriptingConfiguration.java
+++ b/core/src/main/java/org/jboss/arquillian/persistence/script/configuration/ScriptingConfiguration.java
@@ -46,6 +46,8 @@ public class ScriptingConfiguration extends Configuration {
     private TestExecutionPhase defaultCleanupUsingScriptPhase = TestExecutionPhase.AFTER;
 
     private String sqlStatementDelimiter = ";";
+    
+    private boolean trimSqlStatementDelimiter = false;
 
     private boolean showSql = false;
 
@@ -114,6 +116,17 @@ public class ScriptingConfiguration extends Configuration {
      */
     public void setSqlStatementDelimiter(String sqlStatementDelimiter) {
         this.sqlStatementDelimiter = sqlStatementDelimiter;
+    }
+    
+    public boolean isTrimSqlStatementDelimiter() {
+        return trimSqlStatementDelimiter;
+    }
+
+    /**
+     * @param trimSqlStatementDelimiter Defines if the statement delimiter should be removed from the parsed statements. Default value: false
+     */
+    public void setTrimSqlStatementDelimiter(boolean trimSqlStatementDelimiter) {
+        this.trimSqlStatementDelimiter = trimSqlStatementDelimiter;
     }
 
     public boolean isShowSql() {

--- a/core/src/main/java/org/jboss/arquillian/persistence/script/splitter/DefaultStatementSplitter.java
+++ b/core/src/main/java/org/jboss/arquillian/persistence/script/splitter/DefaultStatementSplitter.java
@@ -60,9 +60,12 @@ public class DefaultStatementSplitter implements StatementSplitter {
     private static final String LINE_SEPARATOR = System.getProperty("line.separator", "\n");
 
     private String statementDelimiter;
+    
+    private boolean trimStatementDelimiter;
 
     public DefaultStatementSplitter() {
         this.statementDelimiter = ";";
+        this.trimStatementDelimiter = false;
     }
 
     public DefaultStatementSplitter(String statementDelimiter) {
@@ -72,6 +75,11 @@ public class DefaultStatementSplitter implements StatementSplitter {
     @Override
     public void setStatementDelimiter(String statementDelimiter) {
         this.statementDelimiter = statementDelimiter;
+    }
+    
+    @Override
+    public void setTrimStatementDelimiter(boolean trimStatementDelimiter) {
+        this.trimStatementDelimiter = trimStatementDelimiter;
     }
 
     @Override
@@ -155,6 +163,10 @@ public class DefaultStatementSplitter implements StatementSplitter {
         String trimmed = new SpecialCharactersReplacer().unescape(line.trim());
         if (!lineIsStatementDelimiter(line)) {
             trimmed.replace(LINE_SEPARATOR, " ");
+
+            if (trimStatementDelimiter && trimmed.endsWith(statementDelimiter)) {
+                return trimmed.substring(0, trimmed.length() - statementDelimiter.length());
+            }
         }
         return trimmed;
     }

--- a/core/src/main/java/org/jboss/arquillian/persistence/script/splitter/StatementSplitterResolver.java
+++ b/core/src/main/java/org/jboss/arquillian/persistence/script/splitter/StatementSplitterResolver.java
@@ -43,6 +43,7 @@ public class StatementSplitterResolver {
                 }
                 resolved = statementSplitter;
                 resolved.setStatementDelimiter(scriptingConfiguration.getSqlStatementDelimiter());
+                resolved.setTrimStatementDelimiter(scriptingConfiguration.isTrimSqlStatementDelimiter());
             }
         }
 

--- a/core/src/main/java/org/jboss/arquillian/persistence/script/splitter/oracle/OracleStatementSplitter.java
+++ b/core/src/main/java/org/jboss/arquillian/persistence/script/splitter/oracle/OracleStatementSplitter.java
@@ -69,6 +69,11 @@ public class OracleStatementSplitter implements StatementSplitter {
     }
 
     @Override
+    public void setTrimStatementDelimiter(boolean trimStatementDelimiter) {
+
+    }
+
+    @Override
     public String supports() {
         return "oracle";
     }

--- a/core/src/test/java/org/jboss/arquillian/persistence/script/splitter/DefaultStatementSplitterTest.java
+++ b/core/src/test/java/org/jboss/arquillian/persistence/script/splitter/DefaultStatementSplitterTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.persistence.script.splitter;
+
+import java.util.List;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DefaultStatementSplitterTest {
+
+    @Test
+    public void should_not_remove_delimiter_if_delimiter_is_not_present() {
+        String script = "SELECT * FROM TEST";
+
+        DefaultStatementSplitter splitter = new DefaultStatementSplitter();
+        splitter.setTrimStatementDelimiter(true);
+
+        List<String> statements = splitter.splitStatements(script);
+
+        assertThat(statements).containsExactly("SELECT * FROM TEST");
+    }
+
+    @Test
+    public void should_remove_delimiter_on_single_statement() {
+        String script = "SELECT * FROM TEST;";
+
+        DefaultStatementSplitter splitter = new DefaultStatementSplitter();
+        splitter.setTrimStatementDelimiter(true);
+
+        List<String> statements = splitter.splitStatements(script);
+
+        assertThat(statements).containsExactly("SELECT * FROM TEST");
+    }
+
+    @Test
+    public void should_remove_delimiter_on_multiple_statements() {
+        String script = "SELECT * FROM TEST1;SELECT * FROM TEST2;";
+
+        DefaultStatementSplitter splitter = new DefaultStatementSplitter();
+        splitter.setTrimStatementDelimiter(true);
+
+        List<String> statements = splitter.splitStatements(script);
+
+        assertThat(statements).containsExactly("SELECT * FROM TEST1", "SELECT * FROM TEST2");
+    }
+
+}

--- a/spi/src/main/java/org/jboss/arquillian/persistence/spi/script/StatementSplitter.java
+++ b/spi/src/main/java/org/jboss/arquillian/persistence/spi/script/StatementSplitter.java
@@ -46,6 +46,13 @@ public interface StatementSplitter {
     void setStatementDelimiter(String statementDelimiter);
 
     /**
+     * Defines if the statement delimiter should be removed from the parsed statement
+     *
+     * @param trimStatementDelimiter
+     */
+    void setTrimStatementDelimiter(boolean trimStatementDelimiter);
+    
+    /**
      * Splits given script into executable statements
      *
      * @param script


### PR DESCRIPTION
Adds the possibility to strip the statement delimiter from the parsed statements. E.g. IBM DB2 (Express-C 11.1) does not accept the delimiter in the executed statement.

**Fixes**: #ARQ-2070