### PR TITLE
Espace curly brackets into sql script

### DIFF
--- a/core/src/main/java/org/jboss/arquillian/persistence/script/SpecialCharactersReplacer.java
+++ b/core/src/main/java/org/jboss/arquillian/persistence/script/SpecialCharactersReplacer.java
@@ -22,8 +22,8 @@ public class SpecialCharactersReplacer {
    public String escape(String source)
    {
        String result = source.replaceAll("(?m)&(.[a-zA-Z0-9]*);", "ape_special[$1]");
-       result = result.replace("{", "ape_especial_curly_brackets_begin");
-       result = result.replace("}", "ape_especial_curly_brackets_end");       
+       result = result.replace("\\{", "ape_especial_curly_brackets_begin");
+       result = result.replace("\\}", "ape_especial_curly_brackets_end");       
       return result;
    }
 

--- a/core/src/main/java/org/jboss/arquillian/persistence/script/SpecialCharactersReplacer.java
+++ b/core/src/main/java/org/jboss/arquillian/persistence/script/SpecialCharactersReplacer.java
@@ -19,11 +19,20 @@ package org.jboss.arquillian.persistence.script;
 
 public class SpecialCharactersReplacer {
 
-    public String escape(String source) {
-        return source.replaceAll("(?m)&(.[a-zA-Z0-9]*);", "ape_special[$1]");
-    }
+   public String escape(String source)
+   {
+       String result = source.replaceAll("(?m)&(.[a-zA-Z0-9]*);", "ape_special[$1]");
+       result = result.replace("{", "ape_especial_curly_brackets_begin");
+       result = result.replace("}", "ape_especial_curly_brackets_end");       
+      return result;
+   }
 
-    public String unescape(String source) {
-        return source.replaceAll("(?m)ape_special\\[(.[a-zA-Z0-9]*)]", "&$1;");
-    }
+   public String unescape(String source)
+   {
+       String result = source.replaceAll("(?m)ape_special\\[(.[a-zA-Z0-9]*)]", "&$1;");
+       result = result.replace("ape_especial_curly_brackets_begin", "{");
+       result = result.replace("ape_especial_curly_brackets_end", "}");       
+
+      return result;
+   }
 }

--- a/core/src/test/java/org/jboss/arquillian/persistence/script/ScriptExecutorTest.java
+++ b/core/src/test/java/org/jboss/arquillian/persistence/script/ScriptExecutorTest.java
@@ -315,4 +315,20 @@ public class ScriptExecutorTest {
                 " values (2, 'John', 'Sharp', 'asdqwe', 'closing only</strong>')"
         );
     }
+    
+   @Test
+   public void should_insert_json_tags() throws Exception
+   {
+      // given
+      ArgumentCaptor<String> statementsCaptor = ArgumentCaptor.forClass(String.class);
+
+      // when
+      scriptExecutor.execute(FileLoader.loadAsString("scripts/insert-with-json.sql"));
+
+      // then
+      verify(connection, times(1)).createStatement();
+      verify(connection.createStatement(), times(1)).execute(statementsCaptor.capture());
+      assertThat(statementsCaptor.getAllValues()).containsSequence(
+            "INSERT INTO `com` (`comtxt`) VALUES ('{}');");
+   }      
 }

--- a/core/src/test/resources/scripts/insert-with-json.sql
+++ b/core/src/test/resources/scripts/insert-with-json.sql
@@ -1,1 +1,1 @@
-INSERT INTO `com` (`comtxt`) VALUES ('{}');
+INSERT INTO `com` (`comtxt`) VALUES ('\{\}');

--- a/core/src/test/resources/scripts/insert-with-json.sql
+++ b/core/src/test/resources/scripts/insert-with-json.sql
@@ -1,0 +1,1 @@
+INSERT INTO `com` (`comtxt`) VALUES ('{}');


### PR DESCRIPTION
<!-- 

Many thanks for contributing to Arquillian! Together we can make the testing world better.

Please tell us what this PR brings following the template we provided. 
And don't forget to link to the issue (or create one if there is none).

If you are still working on the change please prefix this pull request title with "WIP"

YOU CAN DELETE THIS COMMENT :)
-->

#### Short description of what this resolves:
DefaultStatementSplitter use BufferedReader.readLine and if  the line contains curly brackets ({}), those are removed. 

#### Changes proposed in this pull request:

- Escape (and unescape) curly brackets in String read from sql script file.
-
-


**Fixes**: #
