### PR TITLE
Change class visibility to public in extensions definition

### DIFF
--- a/arquillian-ape-nosql/couchbase/src/main/java/org/arquillian/ape/nosql/couchbase/CouchbasePopulatorExtension.java
+++ b/arquillian-ape-nosql/couchbase/src/main/java/org/arquillian/ape/nosql/couchbase/CouchbasePopulatorExtension.java
@@ -9,7 +9,7 @@ import org.arquillian.ape.spi.PopulatorService;
 import org.jboss.arquillian.core.spi.LoadableExtension;
 import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
 
-class CouchbasePopulatorExtension implements LoadableExtension, JUnitRuleSupport {
+public class CouchbasePopulatorExtension implements LoadableExtension, JUnitRuleSupport {
 
     @Override
     public void register(ExtensionBuilder extensionBuilder) {

--- a/arquillian-ape-nosql/couchdb/src/main/java/org/arquillian/ape/nosql/couchdb/CouchDbPopulatorExtension.java
+++ b/arquillian-ape-nosql/couchdb/src/main/java/org/arquillian/ape/nosql/couchdb/CouchDbPopulatorExtension.java
@@ -9,7 +9,7 @@ import org.arquillian.ape.spi.PopulatorService;
 import org.jboss.arquillian.core.spi.LoadableExtension;
 import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
 
-class CouchDbPopulatorExtension implements LoadableExtension, JUnitRuleSupport {
+public class CouchDbPopulatorExtension implements LoadableExtension, JUnitRuleSupport {
 
     @Override
     public void register(ExtensionBuilder extensionBuilder) {

--- a/arquillian-ape-nosql/mongodb/src/main/java/org/arquillian/ape/nosql/mongodb/MongoDbPopulatorExtension.java
+++ b/arquillian-ape-nosql/mongodb/src/main/java/org/arquillian/ape/nosql/mongodb/MongoDbPopulatorExtension.java
@@ -9,7 +9,7 @@ import org.arquillian.ape.spi.PopulatorService;
 import org.jboss.arquillian.core.spi.LoadableExtension;
 import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
 
-class MongoDbPopulatorExtension implements LoadableExtension, JUnitRuleSupport {
+public class MongoDbPopulatorExtension implements LoadableExtension, JUnitRuleSupport {
 
     @Override
     public void register(ExtensionBuilder extensionBuilder) {

--- a/arquillian-ape-nosql/redis/src/main/java/org/arquillian/ape/nosql/redis/RedisPopulatorExtension.java
+++ b/arquillian-ape-nosql/redis/src/main/java/org/arquillian/ape/nosql/redis/RedisPopulatorExtension.java
@@ -9,7 +9,7 @@ import org.arquillian.ape.spi.PopulatorService;
 import org.jboss.arquillian.core.spi.LoadableExtension;
 import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
 
-class RedisPopulatorExtension implements LoadableExtension, JUnitRuleSupport {
+public class RedisPopulatorExtension implements LoadableExtension, JUnitRuleSupport {
 
     @Override
     public void register(ExtensionBuilder extensionBuilder) {

--- a/arquillian-ape-rest/postman/src/main/java/org/arquillian/ape/rest/postman/PostmanPopulatorExtension.java
+++ b/arquillian-ape-rest/postman/src/main/java/org/arquillian/ape/rest/postman/PostmanPopulatorExtension.java
@@ -9,7 +9,7 @@ import org.arquillian.ape.spi.PopulatorService;
 import org.jboss.arquillian.core.spi.LoadableExtension;
 import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
 
-class PostmanPopulatorExtension implements LoadableExtension, JUnitRuleSupport {
+public class PostmanPopulatorExtension implements LoadableExtension, JUnitRuleSupport {
     @Override
     public void register(ExtensionBuilder extensionBuilder) {
         extensionBuilder.service(PopulatorService.class, PostmanPopulatorService.class)


### PR DESCRIPTION
#### Short description of what this resolves:

Change class visibility to public in extensions definition so in case of using JUnit rule they can be instantiated as well.

#### Changes proposed in this pull request:

- All NoSQL and REST extensions main class changed visibility to public
