### PR TITLE
feat(ARQ-2148): Implements Spring Boot, JPA and Wildfly Swarm support

### DIFF
--- a/arquillian-ape-spi/src/main/java/org/arquillian/ape/spi/Populator.java
+++ b/arquillian-ape-spi/src/main/java/org/arquillian/ape/spi/Populator.java
@@ -48,6 +48,11 @@ public abstract class Populator<T extends PopulatorService, R extends Populator.
         return createExecutor();
     }
 
+    public R project() {
+        this.uri = URI.create("");
+        return createExecutor();
+    }
+
     /**
      * Initial method for Populators DSL
      *

--- a/arquillian-ape-sql/standalone/core/pom.xml
+++ b/arquillian-ape-sql/standalone/core/pom.xml
@@ -21,6 +21,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.yaml</groupId>
+      <artifactId>snakeyaml</artifactId>
+      <version>${version.snakeyaml}</version>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/arquillian-ape-sql/standalone/core/pom.xml
+++ b/arquillian-ape-sql/standalone/core/pom.xml
@@ -35,6 +35,12 @@
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+      <version>1.4.195</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/arquillian-ape-sql/standalone/core/pom.xml
+++ b/arquillian-ape-sql/standalone/core/pom.xml
@@ -20,6 +20,16 @@
       <artifactId>arquillian-ape-core</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/arquillian-ape-sql/standalone/core/src/main/java/org/arquillian/ape/rdbms/core/DatabaseConfiguration.java
+++ b/arquillian-ape-sql/standalone/core/src/main/java/org/arquillian/ape/rdbms/core/DatabaseConfiguration.java
@@ -1,0 +1,53 @@
+package org.arquillian.ape.rdbms.core;
+
+import java.net.URI;
+
+class DatabaseConfiguration {
+
+    private URI jdbc;
+    private Class<?> jdbcDriver;
+    private String username;
+    private String password;
+
+    DatabaseConfiguration() {
+    }
+
+    DatabaseConfiguration(URI jdbc, Class<?> jdbcDriver, String username, String password) {
+        this.jdbc = jdbc;
+        this.jdbcDriver = jdbcDriver;
+        this.username = username;
+        this.password = password;
+    }
+
+    void setJdbc(URI jdbc) {
+        this.jdbc = jdbc;
+    }
+
+    void setJdbcDriver(Class<?> jdbcDriver) {
+        this.jdbcDriver = jdbcDriver;
+    }
+
+    void setUsername(String username) {
+        this.username = username;
+    }
+
+    void setPassword(String password) {
+        this.password = password;
+    }
+
+    URI getJdbc() {
+        return jdbc;
+    }
+
+    Class<?> getJdbcDriver() {
+        return jdbcDriver;
+    }
+
+    String getUsername() {
+        return username;
+    }
+
+    String getPassword() {
+        return password;
+    }
+}

--- a/arquillian-ape-sql/standalone/core/src/main/java/org/arquillian/ape/rdbms/core/JpaPersistenceLoader.java
+++ b/arquillian-ape-sql/standalone/core/src/main/java/org/arquillian/ape/rdbms/core/JpaPersistenceLoader.java
@@ -1,0 +1,62 @@
+package org.arquillian.ape.rdbms.core;
+
+import java.io.InputStream;
+import java.net.URI;
+import javax.xml.namespace.QName;
+import javax.xml.stream.XMLEventReader;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.events.Attribute;
+import javax.xml.stream.events.StartElement;
+import javax.xml.stream.events.XMLEvent;
+import org.arquillian.ape.core.RunnerExpressionParser;
+
+public class JpaPersistenceLoader {
+
+    private static final String JDBC_URI_PROPERTY_NAME = "javax.persistence.jdbc.url";
+    private static final String USERNAME_PROPERTY_NAME = "javax.persistence.jdbc.user";
+    private static final String PASSWORD_PROPERTY_NAME = "javax.persistence.jdbc.password";
+    private static final String DRIVER_PROPERTY_NAME = "javax.persistence.jdbc.driver";
+
+    public static DatabaseConfiguration load(String location) {
+        final InputStream persistenceContent = Thread.currentThread().getContextClassLoader().getResourceAsStream(location);
+
+        if (persistenceContent == null) {
+            throw new IllegalArgumentException(String.format("Persistence file %s not found in classpath.", location));
+        }
+        DatabaseConfiguration databaseConfiguration = new DatabaseConfiguration();
+        final XMLInputFactory xmlInputFactory = XMLInputFactory.newInstance();
+        try {
+            final XMLEventReader xmlEventReader = xmlInputFactory.createXMLEventReader(persistenceContent);
+            while(xmlEventReader.hasNext()) {
+                final XMLEvent xmlEvent = xmlEventReader.nextEvent();
+                if (xmlEvent.isStartElement()) {
+                    final StartElement startElement = xmlEvent.asStartElement();
+                    if ("property".equalsIgnoreCase(startElement.getName().getLocalPart())) {
+                        final Attribute name = startElement.getAttributeByName(new QName("name"));
+                        if (name != null) {
+                            switch (name.getValue()) {
+                                case JDBC_URI_PROPERTY_NAME: databaseConfiguration.setJdbc(URI.create(extractValue(startElement)));
+                                break;
+                                case USERNAME_PROPERTY_NAME: databaseConfiguration.setUsername(extractValue(startElement));
+                                break;
+                                case PASSWORD_PROPERTY_NAME: databaseConfiguration.setPassword(extractValue(startElement));
+                                break;
+                                case DRIVER_PROPERTY_NAME: databaseConfiguration.setJdbcDriver(Class.forName(extractValue(startElement)));
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+        } catch (XMLStreamException | ClassNotFoundException e) {
+            throw new IllegalArgumentException(e);
+        }
+
+        return databaseConfiguration;
+    }
+
+    private static String extractValue(StartElement startElement) {
+        return RunnerExpressionParser.parseExpressions(startElement.getAttributeByName(new QName("value")).getValue());
+    }
+}

--- a/arquillian-ape-sql/standalone/core/src/main/java/org/arquillian/ape/rdbms/core/RdbmsPopulatorConfigurator.java
+++ b/arquillian-ape-sql/standalone/core/src/main/java/org/arquillian/ape/rdbms/core/RdbmsPopulatorConfigurator.java
@@ -1,6 +1,5 @@
 package org.arquillian.ape.rdbms.core;
 
-import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -14,6 +13,7 @@ public class RdbmsPopulatorConfigurator implements Populator.PopulatorConfigurat
 
     private static final String DEFAULT_SPRING_BOOT_CONFIGURATION_PROPERTIES_FILE = "application.properties";
     private static final String DEFAULT_JPA_CONFIGURATION_FILE = "META-INF/persistence.xml";
+    private static final String DEFAULT_SWARM_CONFIGURATION_FILE = "project-defaults.yml";
 
     private RdbmsPopulatorService populatorService;
     private URI jdbc;
@@ -45,6 +45,24 @@ public class RdbmsPopulatorConfigurator implements Populator.PopulatorConfigurat
 
     public RdbmsPopulatorConfigurator fromSpringBootConfiguration(String location) {
         final DatabaseConfiguration databaseConfiguration = SpringBootLoader.load(location);
+        fillDatabaseConfiguration(databaseConfiguration);
+        return this;
+    }
+
+    public RdbmsPopulatorConfigurator fromWildflySwarmConfiguration() {
+        final DatabaseConfiguration databaseConfiguration = WildflySwarmLoader.load(null, DEFAULT_SWARM_CONFIGURATION_FILE);
+        fillDatabaseConfiguration(databaseConfiguration);
+        return this;
+    }
+
+    public RdbmsPopulatorConfigurator fromWildflySwarmConfiguration(String name) {
+        final DatabaseConfiguration databaseConfiguration = WildflySwarmLoader.load(name, DEFAULT_SWARM_CONFIGURATION_FILE);
+        fillDatabaseConfiguration(databaseConfiguration);
+        return this;
+    }
+
+    public RdbmsPopulatorConfigurator fromWildflySwarmConfiguration(String name, String location) {
+        final DatabaseConfiguration databaseConfiguration = WildflySwarmLoader.load(name, location);
         fillDatabaseConfiguration(databaseConfiguration);
         return this;
     }

--- a/arquillian-ape-sql/standalone/core/src/main/java/org/arquillian/ape/rdbms/core/RdbmsPopulatorConfigurator.java
+++ b/arquillian-ape-sql/standalone/core/src/main/java/org/arquillian/ape/rdbms/core/RdbmsPopulatorConfigurator.java
@@ -1,5 +1,6 @@
 package org.arquillian.ape.rdbms.core;
 
+import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -10,6 +11,9 @@ import java.util.Map;
 import org.arquillian.ape.spi.Populator;
 
 public class RdbmsPopulatorConfigurator implements Populator.PopulatorConfigurator {
+
+    private static final String DEFAULT_SPRING_BOOT_CONFIGURATION_PROPERTIES_FILE = "application.properties";
+    private static final String DEFAULT_JPA_CONFIGURATION_FILE = "META-INF/persistence.xml";
 
     private RdbmsPopulatorService populatorService;
     private URI jdbc;
@@ -23,6 +27,33 @@ public class RdbmsPopulatorConfigurator implements Populator.PopulatorConfigurat
     RdbmsPopulatorConfigurator(URI jdbcUrl, RdbmsPopulatorService populatorService) {
         this.jdbc = jdbcUrl;
         this.populatorService = populatorService;
+    }
+
+    public RdbmsPopulatorConfigurator fromJpaPersistence() {
+        return this.fromJpaPersistence(DEFAULT_JPA_CONFIGURATION_FILE);
+    }
+
+    public RdbmsPopulatorConfigurator fromJpaPersistence(String location) {
+        final DatabaseConfiguration databaseConfiguration = JpaPersistenceLoader.load(location);
+        fillDatabaseConfiguration(databaseConfiguration);
+        return this;
+    }
+
+    public RdbmsPopulatorConfigurator fromSpringBootConfiguration() {
+        return fromSpringBootConfiguration(DEFAULT_SPRING_BOOT_CONFIGURATION_PROPERTIES_FILE);
+    }
+
+    public RdbmsPopulatorConfigurator fromSpringBootConfiguration(String location) {
+        final DatabaseConfiguration databaseConfiguration = SpringBootLoader.load(location);
+        fillDatabaseConfiguration(databaseConfiguration);
+        return this;
+    }
+
+    private void fillDatabaseConfiguration(DatabaseConfiguration databaseConfiguration) {
+        this.driverName = databaseConfiguration.getJdbcDriver();
+        this.jdbc = databaseConfiguration.getJdbc();
+        this.username = databaseConfiguration.getUsername();
+        this.password = databaseConfiguration.getPassword();
     }
 
     public RdbmsPopulatorConfigurator withUsername(String username) {

--- a/arquillian-ape-sql/standalone/core/src/main/java/org/arquillian/ape/rdbms/core/SpringBootLoader.java
+++ b/arquillian-ape-sql/standalone/core/src/main/java/org/arquillian/ape/rdbms/core/SpringBootLoader.java
@@ -1,0 +1,42 @@
+package org.arquillian.ape.rdbms.core;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.util.Properties;
+import org.arquillian.ape.core.RunnerExpressionParser;
+
+public class SpringBootLoader {
+
+    private static final String JDBC_URI_PROPERTY_NAME = "spring.datasource.url";
+    private static final String USERNAME_PROPERTY_NAME = "spring.datasource.username";
+    private static final String PASSWORD_PROPERTY_NAME = "spring.datasource.password";
+    private static final String DRIVER_PROPERTY_NAME = "spring.datasource.driverClassName";
+
+    public static DatabaseConfiguration load(String location) {
+
+        final InputStream configurationFile = Thread.currentThread().getContextClassLoader()
+            .getResourceAsStream(location);
+
+        if (configurationFile == null) {
+            throw new IllegalArgumentException(String.format("Spring Boot configuration file %s not found in classpath.", location));
+        }
+
+        Properties properties = new Properties();
+        try {
+            properties.load(configurationFile);
+
+            final String jdbc = properties.getProperty(JDBC_URI_PROPERTY_NAME);
+            final String driverClass = properties.getProperty(DRIVER_PROPERTY_NAME);
+            final String username = properties.getProperty(USERNAME_PROPERTY_NAME);
+            final String password = properties.getProperty(PASSWORD_PROPERTY_NAME);
+            return new DatabaseConfiguration(URI.create(RunnerExpressionParser.parseExpressions(jdbc)),
+                Class.forName(RunnerExpressionParser.parseExpressions(driverClass)),
+                RunnerExpressionParser.parseExpressions((username)),
+                RunnerExpressionParser.parseExpressions(password));
+        } catch (IOException | ClassNotFoundException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+}

--- a/arquillian-ape-sql/standalone/core/src/main/java/org/arquillian/ape/rdbms/core/WildflySwarmLoader.java
+++ b/arquillian-ape-sql/standalone/core/src/main/java/org/arquillian/ape/rdbms/core/WildflySwarmLoader.java
@@ -1,0 +1,97 @@
+package org.arquillian.ape.rdbms.core;
+
+import java.io.InputStream;
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+import org.yaml.snakeyaml.Yaml;
+
+public class WildflySwarmLoader {
+
+    static final Map<String, String> DEFAULT_DRIVER_NAMES = new HashMap<>();
+
+    static {
+        DEFAULT_DRIVER_NAMES.put("mysql", "com.mysql.jdbc.Driver");
+        DEFAULT_DRIVER_NAMES.put("postgresql", "org.postgresql.Driver");
+        DEFAULT_DRIVER_NAMES.put("h2", "org.h2.Driver");
+        DEFAULT_DRIVER_NAMES.put("edb", "com.edb.Driver");
+        DEFAULT_DRIVER_NAMES.put("ibmdb2", "com.ibm.db2.jcc.DB2Driver");
+        DEFAULT_DRIVER_NAMES.put("oracle", "oracle.jdbc.OracleDriver");
+        DEFAULT_DRIVER_NAMES.put("sqlserver", "com.microsoft.sqlserver.jdbc.SQLServerDriver");
+        DEFAULT_DRIVER_NAMES.put("sybase", "net.sourceforge.jtds.jdbc.Driver");
+        DEFAULT_DRIVER_NAMES.put("teiid", "org.teiid.jdbc.TeiidDriver");
+        DEFAULT_DRIVER_NAMES.put("mariadb", "org.mariadb.jdbc.MariaDbDataSource");
+        DEFAULT_DRIVER_NAMES.put("derby", "org.apache.derby.jdbc.EmbeddedDriver");
+        DEFAULT_DRIVER_NAMES.put("hive2", "org.apache.hive.jdbc.HiveDriver");
+        DEFAULT_DRIVER_NAMES.put("prestodb", "com.simba.presto.jdbc42.Driver");
+    }
+
+    private static final String JDBC_URI_PROPERTY_NAME = "connection-url";
+    private static final String USERNAME_PROPERTY_NAME = "user-name";
+    private static final String PASSWORD_PROPERTY_NAME = "password";
+    private static final String DRIVER_PROPERTY_NAME = "driver-class-name";
+    private static final String DRIVER_NAME = "driver-name";
+
+    public static DatabaseConfiguration load(String name, String location) {
+
+        final DatabaseConfiguration databaseConfiguration = new DatabaseConfiguration();
+
+        final InputStream configurationFile = Thread.currentThread().getContextClassLoader()
+            .getResourceAsStream(location);
+
+        if (configurationFile == null) {
+            throw new IllegalArgumentException(String.format("Wildfly Swarm configuration file %s not found in classpath.", location));
+        }
+
+        final Yaml yaml = new Yaml();
+        final Map<String, Object> configuration = (Map<String, Object>) yaml.load(configurationFile);
+
+        final Map<String, Object> swarm = (Map<String, Object>) configuration.get("swarm");
+        final Map<String, Object> datasources = (Map<String, Object>) swarm.get("datasources");
+
+        final Map<String, Object> data_sources = (Map<String, Object>) datasources.get("data-sources");
+        final Map<String, Object> jdbc_drivers = (Map<String, Object>) datasources.get("jdbc-drivers");
+
+        final String dataSourceName = getDataSourceName(name, data_sources);
+        final Map<String, Object> dataSource = (Map<String, Object>) data_sources.get(dataSourceName);
+
+        String driverName = (String) dataSource.get(DRIVER_NAME);
+        databaseConfiguration.setJdbcDriver(resolveJdbcDriver(driverName, jdbc_drivers));
+        databaseConfiguration.setJdbc(URI.create((String) dataSource.get(JDBC_URI_PROPERTY_NAME)));
+        databaseConfiguration.setUsername((String) dataSource.get(USERNAME_PROPERTY_NAME));
+        databaseConfiguration.setPassword((String) dataSource.get(PASSWORD_PROPERTY_NAME));
+
+        return databaseConfiguration;
+    }
+
+    private static Class<?> resolveJdbcDriver(String driverName, final Map<String, Object> jdbc_drivers) {
+        if (jdbc_drivers != null && jdbc_drivers.containsKey(driverName)) {
+            final Map<String, Object> jdbcDriver = (Map<String, Object>) jdbc_drivers.get(driverName);
+            try {
+               return Class.forName((String) jdbcDriver.get(DRIVER_PROPERTY_NAME));
+            } catch (ClassNotFoundException e) {
+                throw new IllegalArgumentException(e);
+            }
+        } else {
+            if (DEFAULT_DRIVER_NAMES.containsKey(driverName)) {
+                try {
+                    return Class.forName(DEFAULT_DRIVER_NAMES.get(driverName));
+                } catch (ClassNotFoundException e) {
+                    throw new IllegalArgumentException(e);
+                }
+            } else {
+                throw new IllegalArgumentException(String.format("%s driver name could not be resolved to any class driver either in jdbc_drivers nor in default list %s",
+                    driverName, DEFAULT_DRIVER_NAMES));
+            }
+        }
+    }
+
+    private static String getDataSourceName(String name, Map<String, Object> data_sources) {
+        String dataSourceName = name;
+
+        if (name == null) {
+            dataSourceName = data_sources.keySet().iterator().next();
+        }
+        return dataSourceName;
+    }
+}

--- a/arquillian-ape-sql/standalone/core/src/main/java/org/arquillian/ape/rdbms/core/WildflySwarmLoader.java
+++ b/arquillian-ape-sql/standalone/core/src/main/java/org/arquillian/ape/rdbms/core/WildflySwarmLoader.java
@@ -59,8 +59,7 @@ public class WildflySwarmLoader {
         final Map<String, Object> data_sources = Objects.requireNonNull((Map<String, Object>) datasources.get(DATA_SOURCES),
             String.format("Configuration file %s does not contain %s field", location, DATA_SOURCES));
 
-        final Map<String, Object> jdbc_drivers = Objects.requireNonNull((Map<String, Object>) datasources.get(JDBC_DRIVERS),
-            String.format("Configuration file %s does not contain %s field", location, JDBC_DRIVERS));
+        final Map<String, Object> jdbc_drivers =(Map<String, Object>) datasources.get(JDBC_DRIVERS);
 
         final String dataSourceName = getDataSourceName(name, data_sources);
         final Map<String, Object> dataSource = (Map<String, Object>) data_sources.get(dataSourceName);

--- a/arquillian-ape-sql/standalone/core/src/main/java/org/arquillian/ape/rdbms/core/WildflySwarmLoader.java
+++ b/arquillian-ape-sql/standalone/core/src/main/java/org/arquillian/ape/rdbms/core/WildflySwarmLoader.java
@@ -4,11 +4,16 @@ import java.io.InputStream;
 import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import org.yaml.snakeyaml.Yaml;
 
 public class WildflySwarmLoader {
 
     static final Map<String, String> DEFAULT_DRIVER_NAMES = new HashMap<>();
+    public static final String SWARM = "swarm";
+    public static final String DATASOURCES = "datasources";
+    public static final String DATA_SOURCES = "data-sources";
+    public static final String JDBC_DRIVERS = "jdbc-drivers";
 
     static {
         DEFAULT_DRIVER_NAMES.put("mysql", "com.mysql.jdbc.Driver");
@@ -46,11 +51,16 @@ public class WildflySwarmLoader {
         final Yaml yaml = new Yaml();
         final Map<String, Object> configuration = (Map<String, Object>) yaml.load(configurationFile);
 
-        final Map<String, Object> swarm = (Map<String, Object>) configuration.get("swarm");
-        final Map<String, Object> datasources = (Map<String, Object>) swarm.get("datasources");
+        final Map<String, Object> swarm = (Map<String, Object>) configuration.get(SWARM);
 
-        final Map<String, Object> data_sources = (Map<String, Object>) datasources.get("data-sources");
-        final Map<String, Object> jdbc_drivers = (Map<String, Object>) datasources.get("jdbc-drivers");
+        final Map<String, Object> datasources = Objects.requireNonNull((Map < String, Object >) swarm.get(DATASOURCES),
+            String.format("Configuration file %s does not contain %s field", location, DATASOURCES));
+
+        final Map<String, Object> data_sources = Objects.requireNonNull((Map<String, Object>) datasources.get(DATA_SOURCES),
+            String.format("Configuration file %s does not contain %s field", location, DATA_SOURCES));
+
+        final Map<String, Object> jdbc_drivers = Objects.requireNonNull((Map<String, Object>) datasources.get(JDBC_DRIVERS),
+            String.format("Configuration file %s does not contain %s field", location, JDBC_DRIVERS));
 
         final String dataSourceName = getDataSourceName(name, data_sources);
         final Map<String, Object> dataSource = (Map<String, Object>) data_sources.get(dataSourceName);

--- a/arquillian-ape-sql/standalone/core/src/test/java/org/arquillian/ape/rdbms/core/RdbmsPopulatorConfiguratorTest.java
+++ b/arquillian-ape-sql/standalone/core/src/test/java/org/arquillian/ape/rdbms/core/RdbmsPopulatorConfiguratorTest.java
@@ -48,4 +48,58 @@ public class RdbmsPopulatorConfiguratorTest {
                 new HashMap<>());
     }
 
+    @Test
+    public void should_load_wildfly_swarm_from_default_location() {
+
+        // given
+        RdbmsPopulatorConfigurator rdbmsPopulatorConfigurator =
+            new RdbmsPopulatorConfigurator(null, rdbmsPopulatorService);
+
+        // when
+        rdbmsPopulatorConfigurator.fromWildflySwarmConfiguration().execute();
+
+        // then
+        Mockito.verify(rdbmsPopulatorService, times(1))
+            .connect(URI.create("jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE"), "sa", "sa", String.class,
+                new HashMap<>());
+    }
+
+    @Test
+    public void should_load_wildfly_swarm_from_default_location_and_concrete_name() {
+
+        // given
+        RdbmsPopulatorConfigurator rdbmsPopulatorConfigurator =
+            new RdbmsPopulatorConfigurator(null, rdbmsPopulatorService);
+
+        // when
+        rdbmsPopulatorConfigurator.fromWildflySwarmConfiguration("MyDS").execute();
+
+        // then
+        Mockito.verify(rdbmsPopulatorService, times(1))
+            .connect(URI.create("jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE"), "sa", "sa", String.class,
+                new HashMap<>());
+    }
+
+    @Test
+    public void should_load_wildfly_swarm_from_specific_location_and_autoresolution_of_driver() {
+
+        try {
+            // given
+            WildflySwarmLoader.DEFAULT_DRIVER_NAMES.put("h2", "java.lang.String");
+            RdbmsPopulatorConfigurator rdbmsPopulatorConfigurator =
+                new RdbmsPopulatorConfigurator(null, rdbmsPopulatorService);
+
+            // when
+            rdbmsPopulatorConfigurator.fromWildflySwarmConfiguration("MyDS", "custom-project-defaults.yml").execute();
+
+            // then
+            Mockito.verify(rdbmsPopulatorService, times(1))
+                .connect(URI.create("jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE"), "sa", "sa",
+                    String.class,
+                    new HashMap<>());
+        } finally {
+            WildflySwarmLoader.DEFAULT_DRIVER_NAMES.put("h2", "org.h2.Driver");
+        }
+    }
+
 }

--- a/arquillian-ape-sql/standalone/core/src/test/java/org/arquillian/ape/rdbms/core/RdbmsPopulatorConfiguratorTest.java
+++ b/arquillian-ape-sql/standalone/core/src/test/java/org/arquillian/ape/rdbms/core/RdbmsPopulatorConfiguratorTest.java
@@ -1,0 +1,51 @@
+package org.arquillian.ape.rdbms.core;
+
+import java.net.URI;
+import java.util.HashMap;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.mockito.Mockito.times;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RdbmsPopulatorConfiguratorTest {
+
+    @Mock
+    RdbmsPopulatorService rdbmsPopulatorService;
+
+    @Test
+    public void should_load_spring_boot_properties_from_default_location() {
+
+        // given
+        RdbmsPopulatorConfigurator rdbmsPopulatorConfigurator =
+            new RdbmsPopulatorConfigurator(null, rdbmsPopulatorService);
+
+        // when
+        rdbmsPopulatorConfigurator.fromSpringBootConfiguration().execute();
+
+        // then
+        Mockito.verify(rdbmsPopulatorService, times(1))
+            .connect(URI.create("jdbc:postgresql://localhost:5432/books"), "postgres", "postgres", String.class,
+                new HashMap<>());
+    }
+
+    @Test
+    public void should_load_jpa_persistence_from_default_location() {
+
+        // given
+        RdbmsPopulatorConfigurator rdbmsPopulatorConfigurator =
+            new RdbmsPopulatorConfigurator(null, rdbmsPopulatorService);
+
+        // when
+        rdbmsPopulatorConfigurator.fromJpaPersistence().execute();
+
+        // then
+        Mockito.verify(rdbmsPopulatorService, times(1))
+            .connect(URI.create("jdbc:postgresql://192.168.99.100:5432/conference"), "postgres", "postgres", String.class,
+                new HashMap<>());
+    }
+
+}

--- a/arquillian-ape-sql/standalone/core/src/test/java/org/arquillian/ape/rdbms/core/RdbmsPopulatorConfiguratorTest.java
+++ b/arquillian-ape-sql/standalone/core/src/test/java/org/arquillian/ape/rdbms/core/RdbmsPopulatorConfiguratorTest.java
@@ -2,6 +2,7 @@ package org.arquillian.ape.rdbms.core;
 
 import java.net.URI;
 import java.util.HashMap;
+import org.h2.Driver;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -28,7 +29,7 @@ public class RdbmsPopulatorConfiguratorTest {
 
         // then
         Mockito.verify(rdbmsPopulatorService, times(1))
-            .connect(URI.create("jdbc:postgresql://localhost:5432/books"), "postgres", "postgres", String.class,
+            .connect(URI.create("jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE"), "sa", "sa", Driver.class,
                 new HashMap<>());
     }
 
@@ -44,7 +45,7 @@ public class RdbmsPopulatorConfiguratorTest {
 
         // then
         Mockito.verify(rdbmsPopulatorService, times(1))
-            .connect(URI.create("jdbc:postgresql://192.168.99.100:5432/conference"), "postgres", "postgres", String.class,
+            .connect(URI.create("jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE"), "sa", "sa", Driver.class,
                 new HashMap<>());
     }
 
@@ -60,7 +61,7 @@ public class RdbmsPopulatorConfiguratorTest {
 
         // then
         Mockito.verify(rdbmsPopulatorService, times(1))
-            .connect(URI.create("jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE"), "sa", "sa", String.class,
+            .connect(URI.create("jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE"), "sa", "sa", org.h2.Driver.class,
                 new HashMap<>());
     }
 
@@ -76,30 +77,25 @@ public class RdbmsPopulatorConfiguratorTest {
 
         // then
         Mockito.verify(rdbmsPopulatorService, times(1))
-            .connect(URI.create("jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE"), "sa", "sa", String.class,
+            .connect(URI.create("jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE"), "sa", "sa", org.h2.Driver.class,
                 new HashMap<>());
     }
 
     @Test
     public void should_load_wildfly_swarm_from_specific_location_and_autoresolution_of_driver() {
 
-        try {
-            // given
-            WildflySwarmLoader.DEFAULT_DRIVER_NAMES.put("h2", "java.lang.String");
-            RdbmsPopulatorConfigurator rdbmsPopulatorConfigurator =
-                new RdbmsPopulatorConfigurator(null, rdbmsPopulatorService);
+        // given
+        RdbmsPopulatorConfigurator rdbmsPopulatorConfigurator =
+            new RdbmsPopulatorConfigurator(null, rdbmsPopulatorService);
 
-            // when
-            rdbmsPopulatorConfigurator.fromWildflySwarmConfiguration("MyDS", "custom-project-defaults.yml").execute();
+        // when
+        rdbmsPopulatorConfigurator.fromWildflySwarmConfiguration("MyDS", "custom-project-defaults.yml").execute();
 
-            // then
-            Mockito.verify(rdbmsPopulatorService, times(1))
-                .connect(URI.create("jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE"), "sa", "sa",
-                    String.class,
-                    new HashMap<>());
-        } finally {
-            WildflySwarmLoader.DEFAULT_DRIVER_NAMES.put("h2", "org.h2.Driver");
-        }
+        // then
+        Mockito.verify(rdbmsPopulatorService, times(1))
+            .connect(URI.create("jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE"), "sa", "sa",
+                org.h2.Driver.class,
+                new HashMap<>());
     }
 
 }

--- a/arquillian-ape-sql/standalone/core/src/test/resources/META-INF/persistence.xml
+++ b/arquillian-ape-sql/standalone/core/src/test/resources/META-INF/persistence.xml
@@ -5,15 +5,10 @@
     <jta-data-source>java:jboss/datasources/ExampleDS</jta-data-source>
     <exclude-unlisted-classes>false</exclude-unlisted-classes>
     <properties>
-      <property name="javax.persistence.jdbc.driver" value="java.lang.String" />
-      <property name="javax.persistence.jdbc.url" value="jdbc:postgresql://192.168.99.100:5432/conference" />
-      <property name="javax.persistence.jdbc.user" value="postgres" />
-      <property name="javax.persistence.jdbc.password" value="postgres" />
-      <property name="hibernate.hbm2ddl.auto" value="create"/>
-      <property name="hibernate.show_sql" value="true"/>
-      <property name="hibernate.format_sql" value="true"/>
-      <property name="hibernate.transaction.flush_before_completion" value="true"/>
-      <property name="hibernate.dialect" value="org.hibernate.dialect.PostgreSQLDialect"/>
+      <property name="javax.persistence.jdbc.driver" value="org.h2.Driver" />
+      <property name="javax.persistence.jdbc.url" value="jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE" />
+      <property name="javax.persistence.jdbc.user" value="sa" />
+      <property name="javax.persistence.jdbc.password" value="sa" />
     </properties>
   </persistence-unit>
 </persistence>

--- a/arquillian-ape-sql/standalone/core/src/test/resources/META-INF/persistence.xml
+++ b/arquillian-ape-sql/standalone/core/src/test/resources/META-INF/persistence.xml
@@ -1,0 +1,19 @@
+<persistence xmlns="http://xmlns.jcp.org/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="2.1" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_1.xsd">
+  <persistence-unit name="conference-persistence-unit" transaction-type="JTA">
+    <description>Forge Persistence Unit</description>
+    <provider>org.hibernate.ejb.HibernatePersistence</provider>
+    <jta-data-source>java:jboss/datasources/ExampleDS</jta-data-source>
+    <exclude-unlisted-classes>false</exclude-unlisted-classes>
+    <properties>
+      <property name="javax.persistence.jdbc.driver" value="java.lang.String" />
+      <property name="javax.persistence.jdbc.url" value="jdbc:postgresql://192.168.99.100:5432/conference" />
+      <property name="javax.persistence.jdbc.user" value="postgres" />
+      <property name="javax.persistence.jdbc.password" value="postgres" />
+      <property name="hibernate.hbm2ddl.auto" value="create"/>
+      <property name="hibernate.show_sql" value="true"/>
+      <property name="hibernate.format_sql" value="true"/>
+      <property name="hibernate.transaction.flush_before_completion" value="true"/>
+      <property name="hibernate.dialect" value="org.hibernate.dialect.PostgreSQLDialect"/>
+    </properties>
+  </persistence-unit>
+</persistence>

--- a/arquillian-ape-sql/standalone/core/src/test/resources/application.properties
+++ b/arquillian-ape-sql/standalone/core/src/test/resources/application.properties
@@ -1,8 +1,4 @@
-spring.datasource.url=jdbc:postgresql://localhost:5432/books
-spring.datasource.username=postgres
-spring.datasource.password=postgres
-spring.datasource.driverClassName=java.lang.String
-spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
-spring.jpa.show-sql=true
-spring.jpa.hibernate.ddl-auto=create
-logging.level.org.springframework.test=INFO
+spring.datasource.url=jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+spring.datasource.username=sa
+spring.datasource.password=sa
+spring.datasource.driverClassName=org.h2.Driver

--- a/arquillian-ape-sql/standalone/core/src/test/resources/application.properties
+++ b/arquillian-ape-sql/standalone/core/src/test/resources/application.properties
@@ -1,0 +1,8 @@
+spring.datasource.url=jdbc:postgresql://localhost:5432/books
+spring.datasource.username=postgres
+spring.datasource.password=postgres
+spring.datasource.driverClassName=java.lang.String
+spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
+spring.jpa.show-sql=true
+spring.jpa.hibernate.ddl-auto=create
+logging.level.org.springframework.test=INFO

--- a/arquillian-ape-sql/standalone/core/src/test/resources/custom-project-defaults.yml
+++ b/arquillian-ape-sql/standalone/core/src/test/resources/custom-project-defaults.yml
@@ -1,0 +1,8 @@
+swarm:
+  datasources:
+    data-sources:
+      MyDS:
+        driver-name: h2
+        connection-url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+        user-name: sa
+        password: sa

--- a/arquillian-ape-sql/standalone/core/src/test/resources/project-defaults.yml
+++ b/arquillian-ape-sql/standalone/core/src/test/resources/project-defaults.yml
@@ -8,6 +8,6 @@ swarm:
         password: sa
     jdbc-drivers:
       myh2:
-        driver-class-name: java.lang.String
+        driver-class-name: org.h2.Driver
         xa-datasource-name: org.h2.jdbcx.JdbcDataSource
         driver-module-name: com.h2database.h2

--- a/arquillian-ape-sql/standalone/core/src/test/resources/project-defaults.yml
+++ b/arquillian-ape-sql/standalone/core/src/test/resources/project-defaults.yml
@@ -1,0 +1,13 @@
+swarm:
+  datasources:
+    data-sources:
+      MyDS:
+        driver-name: myh2
+        connection-url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+        user-name: sa
+        password: sa
+    jdbc-drivers:
+      myh2:
+        driver-class-name: java.lang.String
+        xa-datasource-name: org.h2.jdbcx.JdbcDataSource
+        driver-module-name: com.h2database.h2


### PR DESCRIPTION
#### Short description of what this resolves:
Add a DSL method to load connection SQL configuration values from `persistence.xml` or `application.properties`.

#### Changes proposed in this pull request:

- Adds loader for Spring Boot configuration file
- Adds loader for JPA configuration file


**Fixes**: ARQ-2148 (https://issues.jboss.org/browse/ARQ-2148)
