### PR TITLE
feat(#103): Add support for embedded nosql db

### DIFF
--- a/arquillian-ape-nosql/core/src/main/java/org/arquillian/ape/nosql/NoSqlPopulatorConfigurator.java
+++ b/arquillian-ape-nosql/core/src/main/java/org/arquillian/ape/nosql/NoSqlPopulatorConfigurator.java
@@ -7,7 +7,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Supplier;
 import org.arquillian.ape.spi.Populator;
 
 /**

--- a/arquillian-ape-nosql/core/src/main/java/org/arquillian/ape/nosql/NoSqlPopulatorConfigurator.java
+++ b/arquillian-ape-nosql/core/src/main/java/org/arquillian/ape/nosql/NoSqlPopulatorConfigurator.java
@@ -7,6 +7,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 import org.arquillian.ape.spi.Populator;
 
 /**
@@ -113,6 +114,15 @@ public class NoSqlPopulatorConfigurator implements Populator.PopulatorConfigurat
         return this;
     }
 
+    public void execute(Object connection) {
+        try {
+            connect(connection);
+            populatorService.execute(Collections.unmodifiableList(datasets));
+        } finally {
+            populatorService.disconnect();
+        }
+    }
+
     @Override
     public void execute() {
         // TODO Improve this so connect and disconnect only happens once.
@@ -123,6 +133,10 @@ public class NoSqlPopulatorConfigurator implements Populator.PopulatorConfigurat
         } finally {
             populatorService.disconnect();
         }
+    }
+
+    private void connect(Object connection) {
+        populatorService.connect(connection, database, options);
     }
 
     private void connect() {

--- a/arquillian-ape-nosql/core/src/main/java/org/arquillian/ape/nosql/NoSqlPopulatorService.java
+++ b/arquillian-ape-nosql/core/src/main/java/org/arquillian/ape/nosql/NoSqlPopulatorService.java
@@ -3,8 +3,6 @@ package org.arquillian.ape.nosql;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Consumer;
-import java.util.function.Supplier;
 import org.arquillian.ape.spi.PopulatorService;
 
 /**

--- a/arquillian-ape-nosql/core/src/main/java/org/arquillian/ape/nosql/NoSqlPopulatorService.java
+++ b/arquillian-ape-nosql/core/src/main/java/org/arquillian/ape/nosql/NoSqlPopulatorService.java
@@ -3,6 +3,8 @@ package org.arquillian.ape.nosql;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
 import org.arquillian.ape.spi.PopulatorService;
 
 /**
@@ -11,6 +13,18 @@ import org.arquillian.ape.spi.PopulatorService;
  * You can think about this interface as wrapper to real connection against service.
  */
 public interface NoSqlPopulatorService<T> extends PopulatorService<T> {
+
+    /**
+     * This method is used to set directly the connection to the service.
+     *
+     * Useful for embedded inmemory connections where there is no network implied or for mocking.
+     *
+     * @param embeddedConnection to use.
+     * @param database to use.
+     * @param customOptions to use for connection.
+     */
+    void connect(Object embeddedConnection, String database, Map<String, Object> customOptions);
+
     /**
      * Methods called to connect to the backend.
      *

--- a/arquillian-ape-nosql/couchbase/src/main/java/org/arquillian/ape/nosql/couchbase/CouchbasePopulatorService.java
+++ b/arquillian-ape-nosql/couchbase/src/main/java/org/arquillian/ape/nosql/couchbase/CouchbasePopulatorService.java
@@ -21,6 +21,16 @@ class CouchbasePopulatorService implements NoSqlPopulatorService<Couchbase> {
     private Bucket bucket;
 
     @Override
+    public void connect(Object embeddedConnection, String database, Map<String, Object> customOptions) {
+        if (database == null) {
+            database = "default";
+        }
+
+        this.couchbaseCluster = (CouchbaseCluster) embeddedConnection;
+        connectToBucket(database, customOptions);
+    }
+
+    @Override
     public void connect(String host, int port, String database, Map<String, Object> customOptions) {
         if (database == null) {
             database = "default";

--- a/arquillian-ape-nosql/couchdb/src/main/java/org/arquillian/ape/nosql/couchdb/CouchDbPopulatorService.java
+++ b/arquillian-ape-nosql/couchdb/src/main/java/org/arquillian/ape/nosql/couchdb/CouchDbPopulatorService.java
@@ -20,6 +20,11 @@ class CouchDbPopulatorService implements NoSqlPopulatorService<CouchDb> {
     private CouchDbConnector couchDbConnector;
 
     @Override
+    public void connect(Object embeddedConnection, String database, Map<String, Object> customOptions) {
+        this.couchDbConnector = (CouchDbConnector) embeddedConnection;
+    }
+
+    @Override
     public void connect(String host, int port, String database, Map<String, Object> customOptions) {
         this.couchDbConnector = couchDbConnector(createCouchDbClusterUri(host, port), database, customOptions);
     }

--- a/arquillian-ape-nosql/infinispan/src/main/java/org/arquillian/ape/nosql/infinispan/InfinispanPopulatorService.java
+++ b/arquillian-ape-nosql/infinispan/src/main/java/org/arquillian/ape/nosql/infinispan/InfinispanPopulatorService.java
@@ -10,10 +10,24 @@ import org.arquillian.ape.nosql.NoSqlPopulatorService;
 import org.infinispan.client.hotrod.RemoteCacheManager;
 import org.infinispan.client.hotrod.configuration.ConfigurationBuilder;
 import org.infinispan.commons.api.BasicCache;
+import org.infinispan.commons.api.BasicCacheContainer;
 
 class InfinispanPopulatorService implements NoSqlPopulatorService<Infinispan> {
 
     private BasicCache<Object, Object> infinispanBasicCache;
+
+    @Override
+    public void connect(Object embeddedConnection, String database, Map<String, Object> customOptions) {
+
+        BasicCacheContainer cacheContainer = (BasicCacheContainer) embeddedConnection;
+
+        if (database == null) {
+            infinispanBasicCache = cacheContainer.getCache();
+        } else {
+            infinispanBasicCache = cacheContainer.getCache(database);
+        }
+
+    }
 
     @Override
     public void connect(String host, int port, String database, Map<String, Object> customOptions) {

--- a/arquillian-ape-nosql/mongodb-ftest/pom.xml
+++ b/arquillian-ape-nosql/mongodb-ftest/pom.xml
@@ -10,7 +10,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <properties>
-    <mongodb-driver.version>3.2.2</mongodb-driver.version>
+    <mongodb-driver.version>3.5.0</mongodb-driver.version>
   </properties>
 
   <artifactId>arquillian-ape-nosql-mongodb-ftest</artifactId>
@@ -44,6 +44,12 @@
     <dependency>
       <groupId>org.jboss.arquillian.junit</groupId>
       <artifactId>arquillian-junit-standalone</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.github.fakemongo</groupId>
+      <artifactId>fongo</artifactId>
+      <version>2.1.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/arquillian-ape-nosql/mongodb-ftest/src/test/java/org/arquilian/ape/nosql/mongodb/FongoDbTest.java
+++ b/arquillian-ape-nosql/mongodb-ftest/src/test/java/org/arquilian/ape/nosql/mongodb/FongoDbTest.java
@@ -1,0 +1,44 @@
+package org.arquilian.ape.nosql.mongodb;
+
+import com.github.fakemongo.Fongo;
+import com.mongodb.client.FindIterable;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+import org.arquillian.ape.nosql.NoSqlPopulator;
+import org.arquillian.ape.nosql.mongodb.MongoDb;
+import org.bson.Document;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(Arquillian.class)
+public class FongoDbTest {
+
+    @ArquillianResource
+    @MongoDb
+    NoSqlPopulator populator;
+
+    private static Fongo fongo = new Fongo("db");
+
+    @Test
+    public void should_populate_fongodb() {
+
+        populator.project()
+            .withStorage("test")
+            .usingDataSet("books.json")
+            .execute(fongo.getMongo());
+
+        final MongoDatabase database = fongo.getMongo().getDatabase("test");
+        final MongoCollection<Document> book = database.getCollection("Book");
+        final FindIterable<Document> documents = book.find();
+
+        assertThat(documents.first())
+            .containsEntry("title", "The Hobbit")
+            .containsEntry("numberOfPages", 293);
+
+    }
+
+}

--- a/arquillian-ape-nosql/mongodb/src/main/java/org/arquillian/ape/nosql/mongodb/MongoDbPopulatorService.java
+++ b/arquillian-ape-nosql/mongodb/src/main/java/org/arquillian/ape/nosql/mongodb/MongoDbPopulatorService.java
@@ -25,6 +25,16 @@ class MongoDbPopulatorService implements NoSqlPopulatorService<MongoDb> {
     private MongoDatabase database;
 
     @Override
+    public void connect(Object embeddedConnection, String database, Map<String, Object> customOptions) {
+        if (database == null) {
+            database = "test";
+        }
+
+        this.mongoClient = (MongoClient) embeddedConnection;
+        this.database = mongoClient.getDatabase(database);
+    }
+
+    @Override
     public void connect(String host, int port, String database, Map<String, Object> customOptions) {
         if (database == null) {
             database = "test";

--- a/arquillian-ape-nosql/redis/src/main/java/org/arquillian/ape/nosql/redis/RedisPopulatorService.java
+++ b/arquillian-ape-nosql/redis/src/main/java/org/arquillian/ape/nosql/redis/RedisPopulatorService.java
@@ -20,6 +20,12 @@ class RedisPopulatorService implements NoSqlPopulatorService<Redis> {
     private Jedis jedis;
 
     @Override
+    public void connect(Object embeddedConnection, String database, Map<String, Object> customOptions) {
+        this.jedis = (Jedis) embeddedConnection;
+        this.jedis.connect();
+    }
+
+    @Override
     public void connect(String host, int port, String database, Map<String, Object> customOptions) {
         RedisOptions redisOptions = new RedisOptions(customOptions);
 

--- a/arquillian-ape-nosql/vault/src/main/java/org/arquillian/ape/nosql/vault/VaultPopulatorService.java
+++ b/arquillian-ape-nosql/vault/src/main/java/org/arquillian/ape/nosql/vault/VaultPopulatorService.java
@@ -14,6 +14,13 @@ class VaultPopulatorService implements NoSqlPopulatorService<Vault>  {
     private VaultConfig vaultConfig;
 
     @Override
+    public void connect(Object embeddedConnection, String database, Map<String, Object> customOptions) {
+        this.vaultConfig = (VaultConfig) embeddedConnection;
+        VaultOptions vaultOptions = new VaultOptions(customOptions);
+        vaultOptions.configure(vaultConfig);
+    }
+
+    @Override
     public void connect(String host, int bindPort, String database, Map<String, Object> customOptions) {
         this.vaultConfig = new VaultConfig();
         vaultConfig.address(host + ":" + bindPort);


### PR DESCRIPTION

#### Short description of what this resolves:

Add support for embedded nosql dbs that does not start a …network connector.

#### Changes proposed in this pull request:

- Add a connect method that receives an `Object` which would be the embedded instance. Notice that it must be an Object because the class who manages the lifecycle of populate/clean is generic one, but each NoSQL engine uses a different one. For example Infinispan uses `EmbeddedConnection` meanwhile Mongo uses `Fongo`.


**Fixes**: #103 
